### PR TITLE
Enable multiple free assessment tools

### DIFF
--- a/app/Models/Tool.php
+++ b/app/Models/Tool.php
@@ -20,6 +20,7 @@ class Tool extends Model
         'description_ar',
         'image',
         'status',
+        'has_free_plan',
     ];
 
     public function domains(): HasMany


### PR DESCRIPTION
## Summary
- allow `Tool` model to manage `has_free_plan`
- adapt free assessment controller to return all free tools
- validate selected tool before creating assessment
- display multiple free tools on free assessment index page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run types` *(fails: error TS1149 about file casing)*
- `php artisan test` *(fails: php: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bc9c7e28c8331969d9ddc8e38ec2d