### PR TITLE
Add English translations and i18n support

### DIFF
--- a/app/Filament/Resources/AssessmentResponseResource.php
+++ b/app/Filament/Resources/AssessmentResponseResource.php
@@ -16,12 +16,28 @@ class AssessmentResponseResource extends Resource
     protected static ?string $navigationIcon = 'heroicon-o-clipboard-document-check';
     protected static ?int $navigationSort = 6;
 
+    public static function getNavigationLabel(): string
+    {
+        return __('filament.resources.assessment_response.navigation_label');
+    }
+
+    public static function getModelLabel(): string
+    {
+        return __('filament.resources.assessment_response.label');
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        return __('filament.resources.assessment_response.plural_label');
+    }
+
     public static function form(Form $form): Form
     {
         return $form
             ->schema([
 
                 Forms\Components\Select::make('criterion_id')
+                    ->label(__('filament.fields.criterion'))
                     ->relationship('criterion', 'name_en')
                     ->required(),
                 Forms\Components\TextInput::make('value')
@@ -30,6 +46,7 @@ class AssessmentResponseResource extends Resource
                     ->minValue(0)
                     ->maxValue(100),
                 Forms\Components\Textarea::make('notes')
+                    ->label(__('filament.fields.notes'))
                     ->maxLength(65535)
                     ->columnSpanFull(),
             ]);
@@ -40,13 +57,13 @@ class AssessmentResponseResource extends Resource
         return $table
             ->columns([
                 Tables\Columns\TextColumn::make('tool.name_en')
-                    ->label('Assessment')
+                    ->label(__('filament.resources.assessment.label'))
                     ->sortable(),
                 Tables\Columns\TextColumn::make('criterion.name_en')
-                    ->label('Criterion')
+                    ->label(__('filament.fields.criterion'))
                     ->sortable(),
                 Tables\Columns\TextColumn::make('criterion.category.name_en')
-                    ->label('Category')
+                    ->label(__('filament.fields.category'))
                     ->sortable(),
                 Tables\Columns\TextColumn::make('value')
                     ->sortable(),
@@ -62,6 +79,7 @@ class AssessmentResponseResource extends Resource
             ->filters([
 
                 Tables\Filters\SelectFilter::make('criterion')
+                    ->label(__('filament.fields.criterion'))
                     ->relationship('criterion', 'name_en'),
             ])
             ->actions([

--- a/app/Filament/Resources/BlogCommentResource.php
+++ b/app/Filament/Resources/BlogCommentResource.php
@@ -22,29 +22,44 @@ class BlogCommentResource extends Resource
 
     protected static ?int $navigationSort = 2;
 
+    public static function getNavigationLabel(): string
+    {
+        return __('filament.resources.blog_comment.navigation_label');
+    }
+
+    public static function getModelLabel(): string
+    {
+        return __('filament.resources.blog_comment.label');
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        return __('filament.resources.blog_comment.plural_label');
+    }
+
     public static function form(Form $form): Form
     {
         return $form
             ->schema([
-                Forms\Components\Section::make('Comment Details')
+                Forms\Components\Section::make(__('filament.form.comment_details'))
                     ->schema([
                         Forms\Components\Select::make('blog_post_id')
-                            ->label('Blog Post')
+                            ->label(__('filament.resources.blog_post.label'))
                             ->relationship('blogPost', 'title')
                             ->required()
                             ->searchable(),
 
                         Forms\Components\Select::make('user_id')
-                            ->label('User')
+                            ->label(__('filament.fields.user'))
                             ->relationship('user', 'name')
                             ->searchable(),
 
                         Forms\Components\TextInput::make('author_name')
-                            ->label('Author Name (Guest)')
+                            ->label(__('filament.fields.author_name'))
                             ->maxLength(255),
 
                         Forms\Components\TextInput::make('author_email')
-                            ->label('Author Email (Guest)')
+                            ->label(__('filament.fields.author_email'))
                             ->email()
                             ->maxLength(255),
 
@@ -53,16 +68,17 @@ class BlogCommentResource extends Resource
                             ->rows(4),
 
                         Forms\Components\Select::make('status')
+                            ->label(__('filament.fields.status'))
                             ->options([
-                                'pending' => 'Pending',
-                                'approved' => 'Approved',
-                                'rejected' => 'Rejected',
+                                'pending' => __('filament.status.pending'),
+                                'approved' => __('filament.status.approved'),
+                                'rejected' => __('filament.status.rejected'),
                             ])
                             ->default('pending')
                             ->required(),
 
                         Forms\Components\Select::make('parent_id')
-                            ->label('Reply To')
+                            ->label(__('filament.fields.reply_to'))
                             ->relationship('parent', 'content')
                             ->getOptionLabelFromRecordUsing(fn (BlogComment $record): string =>
                             Str::limit($record->content, 50)
@@ -77,7 +93,7 @@ class BlogCommentResource extends Resource
         return $table
             ->columns([
                 Tables\Columns\TextColumn::make('blogPost.title')
-                    ->label('Blog Post')
+                    ->label(__('filament.resources.blog_post.label'))
                     ->sortable()
                     ->searchable()
                     ->limit(30),
@@ -99,7 +115,7 @@ class BlogCommentResource extends Resource
                     ]),
 
                 Tables\Columns\IconColumn::make('is_reply')
-                    ->label('Reply')
+                    ->label(__('filament.fields.reply'))
                     ->getStateUsing(fn (BlogComment $record): bool => $record->isReply())
                     ->boolean(),
 
@@ -109,17 +125,19 @@ class BlogCommentResource extends Resource
             ])
             ->filters([
                 Tables\Filters\SelectFilter::make('status')
+                    ->label(__('filament.fields.status'))
                     ->options([
-                        'pending' => 'Pending',
-                        'approved' => 'Approved',
-                        'rejected' => 'Rejected',
+                        'pending' => __('filament.status.pending'),
+                        'approved' => __('filament.status.approved'),
+                        'rejected' => __('filament.status.rejected'),
                     ]),
 
                 Tables\Filters\SelectFilter::make('blog_post')
+                    ->label(__('filament.resources.blog_post.label'))
                     ->relationship('blogPost', 'title'),
 
                 Tables\Filters\Filter::make('is_reply')
-                    ->label('Replies Only')
+                    ->label(__('filament.filters.replies_only'))
                     ->query(fn (Builder $query): Builder => $query->whereNotNull('parent_id')),
             ])
             ->actions([
@@ -148,7 +166,7 @@ class BlogCommentResource extends Resource
                     Tables\Actions\DeleteBulkAction::make(),
 
                     Tables\Actions\BulkAction::make('approve')
-                        ->label('Approve Selected')
+                        ->label(__('filament.actions.approve_selected'))
                         ->icon('heroicon-o-check')
                         ->color('success')
                         ->action(function ($records) {
@@ -156,7 +174,7 @@ class BlogCommentResource extends Resource
                         }),
 
                     Tables\Actions\BulkAction::make('reject')
-                        ->label('Reject Selected')
+                        ->label(__('filament.actions.reject_selected'))
                         ->icon('heroicon-o-x-mark')
                         ->color('danger')
                         ->action(function ($records) {

--- a/app/Filament/Resources/BlogPostResource.php
+++ b/app/Filament/Resources/BlogPostResource.php
@@ -23,11 +23,26 @@ class BlogPostResource extends Resource
 
     protected static ?int $navigationSort = 1;
 
+    public static function getNavigationLabel(): string
+    {
+        return __('filament.resources.blog_post.navigation_label');
+    }
+
+    public static function getModelLabel(): string
+    {
+        return __('filament.resources.blog_post.label');
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        return __('filament.resources.blog_post.plural_label');
+    }
+
     public static function form(Form $form): Form
     {
         return $form
             ->schema([
-                Forms\Components\Section::make('Basic Information')
+                Forms\Components\Section::make(__('filament.form.basic_information'))
                     ->schema([
                         Forms\Components\TextInput::make('title')
                             ->required()
@@ -40,7 +55,7 @@ class BlogPostResource extends Resource
                             }),
 
                         Forms\Components\TextInput::make('title_ar')
-                            ->label('Title (Arabic)')
+                            ->label(__('filament.fields.title_ar'))
                             ->maxLength(255),
 
                         Forms\Components\TextInput::make('slug')
@@ -55,12 +70,12 @@ class BlogPostResource extends Resource
                             ->maxLength(500),
 
                         Forms\Components\Textarea::make('excerpt_ar')
-                            ->label('Excerpt (Arabic)')
+                            ->label(__('filament.fields.excerpt_ar'))
                             ->rows(3)
                             ->maxLength(500),
                     ])->columns(2),
 
-                Forms\Components\Section::make('Content')
+                Forms\Components\Section::make(__('filament.form.content'))
                     ->schema([
                         Forms\Components\RichEditor::make('content')
                             ->required()
@@ -82,7 +97,7 @@ class BlogPostResource extends Resource
                             ]),
 
                         Forms\Components\RichEditor::make('content_ar')
-                            ->label('Content (Arabic)')
+                            ->label(__('filament.fields.content_ar'))
                             ->toolbarButtons([
                                 'attachFiles',
                                 'blockquote',
@@ -101,7 +116,7 @@ class BlogPostResource extends Resource
                             ]),
                     ]),
 
-                Forms\Components\Section::make('Media & Settings')
+                Forms\Components\Section::make(__('filament.form.media_settings'))
                     ->schema([
                         Forms\Components\FileUpload::make('featured_image')
                             ->image()
@@ -136,17 +151,17 @@ class BlogPostResource extends Resource
                             ->required(),
 
                         Forms\Components\DateTimePicker::make('published_at')
-                            ->label('Publish Date & Time')
+                            ->label(__('filament.fields.published_at'))
                             ->native(false),
 
                         Forms\Components\Select::make('author_id')
-                            ->label('Author')
+                            ->label(__('filament.fields.author'))
                             ->relationship('author', 'name')
                             ->default(auth()->id())
                             ->required(),
                     ])->columns(2),
 
-                Forms\Components\Section::make('SEO & Meta Data')
+                Forms\Components\Section::make(__('filament.form.seo_meta_data'))
                     ->schema([
                         Forms\Components\KeyValue::make('meta_data')
                             ->label('Meta Data')
@@ -187,17 +202,17 @@ class BlogPostResource extends Resource
                     ]),
 
                 Tables\Columns\TextColumn::make('views_count')
-                    ->label('Views')
+                    ->label(__('filament.fields.views'))
                     ->sortable()
                     ->alignCenter(),
 
                 Tables\Columns\TextColumn::make('likes_count')
-                    ->label('Likes')
+                    ->label(__('filament.fields.likes'))
                     ->sortable()
                     ->alignCenter(),
 
                 Tables\Columns\TextColumn::make('comments_count')
-                    ->label('Comments')
+                    ->label(__('filament.fields.comments'))
                     ->sortable()
                     ->alignCenter(),
 

--- a/app/Filament/Resources/CategoryResource.php
+++ b/app/Filament/Resources/CategoryResource.php
@@ -16,6 +16,21 @@ class CategoryResource extends Resource
     protected static ?string $navigationIcon = 'heroicon-o-tag';
     protected static ?int $navigationSort = 3;
 
+    public static function getNavigationLabel(): string
+    {
+        return __('filament.resources.category.navigation_label');
+    }
+
+    public static function getModelLabel(): string
+    {
+        return __('filament.resources.category.label');
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        return __('filament.resources.category.plural_label');
+    }
+
     public static function form(Form $form): Form
     {
         return $form
@@ -23,27 +38,27 @@ class CategoryResource extends Resource
                 Forms\Components\Select::make('domain_id')
                     ->relationship('domain', 'name_en')
                     ->required(),
-                Forms\Components\Tabs::make('Translations')
+                Forms\Components\Tabs::make(__('filament.form.translations'))
                     ->tabs([
-                        Forms\Components\Tabs\Tab::make('English')
+                        Forms\Components\Tabs\Tab::make(__('filament.form.english'))
                             ->schema([
                                 Forms\Components\TextInput::make('name_en')
-                                    ->label('Name (English)')
+                                    ->label(__('filament.fields.name_en'))
                                     ->required()
                                     ->maxLength(255),
                                 Forms\Components\Textarea::make('description_en')
-                                    ->label('Description (English)')
+                                    ->label(__('filament.fields.description_en'))
                                     ->maxLength(65535)
                                     ->columnSpanFull(),
                             ]),
-                        Forms\Components\Tabs\Tab::make('Arabic')
+                        Forms\Components\Tabs\Tab::make(__('filament.form.arabic'))
                             ->schema([
                                 Forms\Components\TextInput::make('name_ar')
-                                    ->label('Name (Arabic)')
+                                    ->label(__('filament.fields.name_ar'))
                                     ->required()
                                     ->maxLength(255),
                                 Forms\Components\Textarea::make('description_ar')
-                                    ->label('Description (Arabic)')
+                                    ->label(__('filament.fields.description_ar'))
                                     ->maxLength(65535)
                                     ->columnSpanFull(),
                             ]),
@@ -56,9 +71,10 @@ class CategoryResource extends Resource
                 Forms\Components\TextInput::make('weight_percentage')
                     ->required(),
                 Forms\Components\Select::make('status')
+                    ->label(__('filament.fields.status'))
                     ->options([
-                        'active' => 'Active',
-                        'inactive' => 'Inactive',
+                        'active' => __('filament.status.active'),
+                        'inactive' => __('filament.status.inactive'),
                     ])
                     ->default('active')
                     ->required(),
@@ -70,14 +86,15 @@ class CategoryResource extends Resource
         return $table
             ->columns([
                 Tables\Columns\TextColumn::make('domain.name_en')
-                    ->label('Domain')
+                    ->label(__('filament.fields.domain'))
                     ->sortable(),
                 Tables\Columns\TextColumn::make('name_en')
-                    ->label('Name (English)')
+                    ->label(__('filament.fields.name_en'))
                     ->searchable(),
                 Tables\Columns\TextColumn::make('order')
                     ->sortable(),
-                Tables\Columns\TextColumn::make('weight_percentage'),
+                Tables\Columns\TextColumn::make('weight_percentage')
+                    ->label(__('filament.fields.weight_percentage')),
                 Tables\Columns\BadgeColumn::make('status')
                     ->colors([
                         'danger' => 'inactive',
@@ -94,11 +111,13 @@ class CategoryResource extends Resource
             ])
             ->filters([
                 Tables\Filters\SelectFilter::make('domain')
+                    ->label(__('filament.fields.domain'))
                     ->relationship('domain', 'name_en'),
                 Tables\Filters\SelectFilter::make('status')
+                    ->label(__('filament.fields.status'))
                     ->options([
-                        'active' => 'Active',
-                        'inactive' => 'Inactive',
+                        'active' => __('filament.status.active'),
+                        'inactive' => __('filament.status.inactive'),
                     ]),
             ])
             ->actions([

--- a/app/Filament/Resources/CriterionResource.php
+++ b/app/Filament/Resources/CriterionResource.php
@@ -17,34 +17,50 @@ class CriterionResource extends Resource
     protected static ?string $navigationIcon = 'heroicon-o-clipboard-document-list';
     protected static ?int $navigationSort = 4;
 
+    public static function getNavigationLabel(): string
+    {
+        return __('filament.resources.criterion.navigation_label');
+    }
+
+    public static function getModelLabel(): string
+    {
+        return __('filament.resources.criterion.label');
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        return __('filament.resources.criterion.plural_label');
+    }
+
     public static function form(Form $form): Form
     {
         return $form
             ->schema([
                 Forms\Components\Select::make('category_id')
+                    ->label(__('filament.fields.category'))
                     ->relationship('category', 'name_en')
                     ->required(),
-                Forms\Components\Tabs::make('Translations')
+                Forms\Components\Tabs::make(__('filament.form.translations'))
                     ->tabs([
-                        Forms\Components\Tabs\Tab::make('English')
+                        Forms\Components\Tabs\Tab::make(__('filament.form.english'))
                             ->schema([
                                 Forms\Components\TextInput::make('name_en')
-                                    ->label('Name (English)')
+                                    ->label(__('filament.fields.name_en'))
                                     ->required()
                                     ->maxLength(255),
                                 Forms\Components\Textarea::make('description_en')
-                                    ->label('Description (English)')
+                                    ->label(__('filament.fields.description_en'))
                                     ->maxLength(65535)
                                     ->columnSpanFull(),
                             ]),
-                        Forms\Components\Tabs\Tab::make('Arabic')
+                        Forms\Components\Tabs\Tab::make(__('filament.form.arabic'))
                             ->schema([
                                 Forms\Components\TextInput::make('name_ar')
-                                    ->label('Name (Arabic)')
+                                    ->label(__('filament.fields.name_ar'))
                                     ->required()
                                     ->maxLength(255),
                                 Forms\Components\Textarea::make('description_ar')
-                                    ->label('Description (Arabic)')
+                                    ->label(__('filament.fields.description_ar'))
                                     ->maxLength(65535)
                                     ->columnSpanFull(),
                             ]),
@@ -55,9 +71,10 @@ class CriterionResource extends Resource
                     ->numeric()
                     ->default(0),
                 Forms\Components\Select::make('status')
+                    ->label(__('filament.fields.status'))
                     ->options([
-                        'active' => 'Active',
-                        'inactive' => 'Inactive',
+                        'active' => __('filament.status.active'),
+                        'inactive' => __('filament.status.inactive'),
                     ])
                     ->default('active')
                     ->required(),
@@ -70,10 +87,10 @@ class CriterionResource extends Resource
         return $table
             ->columns([
                 Tables\Columns\TextColumn::make('category.name_en')
-                    ->label('Category')
+                    ->label(__('filament.fields.category'))
                     ->sortable(),
                 Tables\Columns\TextColumn::make('name_en')
-                    ->label('Name (English)')
+                    ->label(__('filament.fields.name_en'))
                     ->searchable(),
                 Tables\Columns\TextColumn::make('order')
                     ->sortable(),
@@ -96,11 +113,13 @@ class CriterionResource extends Resource
             ])
             ->filters([
                 Tables\Filters\SelectFilter::make('category')
+                    ->label(__('filament.fields.category'))
                     ->relationship('category', 'name_en'),
                 Tables\Filters\SelectFilter::make('status')
+                    ->label(__('filament.fields.status'))
                     ->options([
-                        'active' => 'Active',
-                        'inactive' => 'Inactive',
+                        'active' => __('filament.status.active'),
+                        'inactive' => __('filament.status.inactive'),
                     ]),
             ])
             ->actions([

--- a/app/Filament/Resources/DomainResource.php
+++ b/app/Filament/Resources/DomainResource.php
@@ -16,48 +16,68 @@ class DomainResource extends Resource
     protected static ?string $navigationIcon = 'heroicon-o-folder';
     protected static ?int $navigationSort = 2;
 
+    public static function getNavigationLabel(): string
+    {
+        return __('filament.resources.domain.navigation_label');
+    }
+
+    public static function getModelLabel(): string
+    {
+        return __('filament.resources.domain.label');
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        return __('filament.resources.domain.plural_label');
+    }
+
     public static function form(Form $form): Form
     {
         return $form
             ->schema([
                 Forms\Components\Select::make('tool_id')
+                    ->label(__('filament.fields.tool'))
                     ->relationship('tool', 'name_en')
                     ->required(),
-                Forms\Components\Tabs::make('Translations')
+                Forms\Components\Tabs::make(__('filament.form.translations'))
                     ->tabs([
-                        Forms\Components\Tabs\Tab::make('English')
+                        Forms\Components\Tabs\Tab::make(__('filament.form.english'))
                             ->schema([
                                 Forms\Components\TextInput::make('name_en')
-                                    ->label('Name (English)')
+                                    ->label(__('filament.fields.name_en'))
                                     ->required()
                                     ->maxLength(255),
                                 Forms\Components\Textarea::make('description_en')
-                                    ->label('Description (English)')
+                                    ->label(__('filament.fields.description_en'))
                                     ->maxLength(65535)
                                     ->columnSpanFull(),
                             ]),
-                        Forms\Components\Tabs\Tab::make('Arabic')
+                        Forms\Components\Tabs\Tab::make(__('filament.form.arabic'))
                             ->schema([
                                 Forms\Components\TextInput::make('name_ar')
-                                    ->label('Name (Arabic)')
+                                    ->label(__('filament.fields.name_ar'))
                                     ->required()
                                     ->maxLength(255),
                                 Forms\Components\Textarea::make('description_ar')
-                                    ->label('Description (Arabic)')
+                                    ->label(__('filament.fields.description_ar'))
                                     ->maxLength(65535)
                                     ->columnSpanFull(),
                             ]),
                     ])
                     ->columnSpanFull(),
                 Forms\Components\TextInput::make('order')
+                    ->label(__('filament.fields.order'))
                     ->required()
                     ->numeric()
-                    ->default(0), Forms\Components\TextInput::make('weight_percentage')
+                    ->default(0),
+                Forms\Components\TextInput::make('weight_percentage')
+                    ->label(__('filament.fields.weight_percentage'))
                     ->required(),
                 Forms\Components\Select::make('status')
+                    ->label(__('filament.fields.status'))
                     ->options([
-                        'active' => 'Active',
-                        'inactive' => 'Inactive',
+                        'active' => __('filament.status.active'),
+                        'inactive' => __('filament.status.inactive'),
                     ])
                     ->default('active')
                     ->required(),
@@ -69,14 +89,15 @@ class DomainResource extends Resource
         return $table
             ->columns([
                 Tables\Columns\TextColumn::make('tool.name_en')
-                    ->label('Tool')
+                    ->label(__('filament.fields.tool'))
                     ->sortable(),
                 Tables\Columns\TextColumn::make('name_en')
-                    ->label('Name (English)')
+                    ->label(__('filament.fields.name_en'))
                     ->searchable(),
                 Tables\Columns\TextColumn::make('order')
                     ->sortable(),
-                Tables\Columns\TextColumn::make('weight_percentage'),
+                Tables\Columns\TextColumn::make('weight_percentage')
+                    ->label(__('filament.fields.weight_percentage')),
                 Tables\Columns\BadgeColumn::make('status')
                     ->colors([
                         'danger' => 'inactive',
@@ -93,11 +114,13 @@ class DomainResource extends Resource
             ])
             ->filters([
                 Tables\Filters\SelectFilter::make('tool')
+                    ->label(__('filament.fields.tool'))
                     ->relationship('tool', 'name_en'),
                 Tables\Filters\SelectFilter::make('status')
+                    ->label(__('filament.fields.status'))
                     ->options([
-                        'active' => 'Active',
-                        'inactive' => 'Inactive',
+                        'active' => __('filament.status.active'),
+                        'inactive' => __('filament.status.inactive'),
                     ]),
             ])
             ->actions([

--- a/lang/ar/filament.php
+++ b/lang/ar/filament.php
@@ -106,6 +106,16 @@ return [
         'guest_email' => 'بريد الضيف الإلكتروني',
         'title_en' => 'العنوان (بالإنجليزية)',
         'title_ar' => 'العنوان (بالعربية)',
+        'excerpt_ar' => 'الملخص (بالعربية)',
+        'content_ar' => 'المحتوى (بالعربية)',
+        'published_at' => 'تاريخ ووقت النشر',
+        'author' => 'الكاتب',
+        'author_name' => 'اسم الكاتب (زائر)',
+        'author_email' => 'بريد الكاتب (زائر)',
+        'reply_to' => 'الرد على',
+        'views' => 'المشاهدات',
+        'likes' => 'الإعجابات',
+        'comments' => 'التعليقات',
         'started_at' => 'تاريخ البدء',
         'completed_at' => 'تاريخ الإكمال',
 
@@ -121,6 +131,7 @@ return [
         'plan_type' => 'نوع الخطة',
         'subscription_status' => 'حالة الاشتراك',
         'assessments_count' => 'عدد التقييمات',
+        'reply' => 'رد',
 
         // Guest Session fields
         'session_id' => 'معرف الجلسة',
@@ -150,6 +161,8 @@ return [
         'completed' => 'مكتمل',
         'archived' => 'مؤرشف',
         'pending' => 'معلق',
+        'approved' => 'مقبول',
+        'rejected' => 'مرفوض',
         'expired' => 'منتهي الصلاحية',
         'cancelled' => 'ملغي',
     ],
@@ -231,6 +244,8 @@ return [
         'contact_user' => 'التواصل مع المستخدم',
         'view_assessment' => 'عرض التقييم',
         'view_user_in_admin' => 'عرض المستخدم في لوحة الإدارة',
+        'approve_selected' => 'الموافقة على المحدد',
+        'reject_selected' => 'رفض المحدد',
     ],
 
     /*
@@ -278,6 +293,9 @@ return [
         'contact_details' => 'تفاصيل الاتصال',
         'subscription_information' => 'معلومات الاشتراك',
         'user_details' => 'تفاصيل المستخدم',
+        'content' => 'المحتوى',
+        'media_settings' => 'الوسائط والإعدادات',
+        'seo_meta_data' => 'سيو والبيانات الوصفية',
         'assessment_information' => 'معلومات التقييم',
         'session_information' => 'معلومات الجلسة',
         'technical_details' => 'التفاصيل التقنية',
@@ -289,6 +307,7 @@ return [
         'select_option' => 'اختر خيار...',
         'upload_file' => 'رفع ملف',
         'drag_drop_file' => 'اسحب وأفلت الملف هنا أو انقر للتصفح',
+        'comment_details' => 'تفاصيل التعليق',
     ],
 
     /*
@@ -331,6 +350,7 @@ return [
         'last_24_hours' => 'آخر 24 ساعة',
         'last_week' => 'الأسبوع الماضي',
         'last_month' => 'الشهر الماضي',
+        'replies_only' => 'الردود فقط',
     ],
 
     /*

--- a/lang/en/filament.php
+++ b/lang/en/filament.php
@@ -1,0 +1,399 @@
+<?php
+// lang/en/filament.php
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Resource Navigation & Labels
+    |--------------------------------------------------------------------------
+    */
+    'resources' => [
+        'tool' => [
+            'label' => 'Tool',
+            'plural_label' => 'Tools',
+            'navigation_label' => 'Tools',
+            'navigation_group' => 'Assessment Management',
+        ],
+        'domain' => [
+            'label' => 'Domain',
+            'plural_label' => 'Domains',
+            'navigation_label' => 'Domains',
+        ],
+        'category' => [
+            'label' => 'Category',
+            'plural_label' => 'Categories',
+            'navigation_label' => 'Categories',
+        ],
+        'criterion' => [
+            'label' => 'Criterion',
+            'plural_label' => 'Criteria',
+            'navigation_label' => 'Criteria',
+        ],
+        'assessment' => [
+            'label' => 'Assessment',
+            'plural_label' => 'Assessments',
+            'navigation_label' => 'Assessments',
+        ],
+        'assessment_response' => [
+            'label' => 'Assessment Response',
+            'plural_label' => 'Assessment Responses',
+            'navigation_label' => 'Assessment Responses',
+        ],
+        'user' => [
+            'label' => 'User',
+            'plural_label' => 'Users',
+            'navigation_label' => 'Users',
+            'navigation_group' => 'User Management',
+        ],
+        'guest_session' => [
+            'label' => 'Guest Session',
+            'plural_label' => 'Guest Sessions',
+            'navigation_label' => 'Guest Sessions',
+            'navigation_group' => 'Assessment Management',
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Common Field Labels
+    |--------------------------------------------------------------------------
+    */
+    'fields' => [
+        // Basic fields
+        'name' => 'Name',
+        'name_en' => 'Name (English)',
+        'name_ar' => 'Name (Arabic)',
+        'description' => 'Description',
+        'description_en' => 'Description (English)',
+        'description_ar' => 'Description (Arabic)',
+        'status' => 'Status',
+        'order' => 'Order',
+        'image' => 'Image',
+        'created_at' => 'Created At',
+        'updated_at' => 'Updated At',
+
+        // Tool specific fields
+        'tool_id' => 'Tool',
+        'tool' => 'Tool',
+
+        // Domain specific fields
+        'domain_id' => 'Domain',
+        'domain' => 'Domain',
+        'weight_percentage' => 'Weight Percentage',
+
+        // Category specific fields
+        'category_id' => 'Category',
+        'category' => 'Category',
+
+        // Criterion specific fields
+        'criterion_id' => 'Criterion',
+        'criterion' => 'Criterion',
+        'requires_attachment' => 'Requires Attachment',
+
+        // Assessment fields
+        'user_id' => 'User',
+        'user' => 'User',
+        'email' => 'Email',
+        'phone' => 'Phone',
+        'organization' => 'Organization',
+        'company' => 'Company',
+        'company_name' => 'Company Name',
+        'company_type' => 'Company Type',
+        'position' => 'Position',
+        'city' => 'City',
+        'country' => 'Country',
+        'website' => 'Website',
+        'guest_name' => 'Guest Name',
+        'guest_email' => 'Guest Email',
+        'title_en' => 'Title (English)',
+        'title_ar' => 'Title (Arabic)',
+        'excerpt_ar' => 'Excerpt (Arabic)',
+        'content_ar' => 'Content (Arabic)',
+        'published_at' => 'Publish Date & Time',
+        'author' => 'Author',
+        'author_name' => 'Author Name (Guest)',
+        'author_email' => 'Author Email (Guest)',
+        'reply_to' => 'Reply To',
+        'views' => 'Views',
+        'likes' => 'Likes',
+        'comments' => 'Comments',
+        'started_at' => 'Started At',
+        'completed_at' => 'Completed At',
+
+        // Assessment Response fields
+        'response' => 'Response',
+        'value' => 'Value',
+        'notes' => 'Notes',
+        'attachment' => 'Attachment',
+
+        // User fields
+        'password' => 'Password',
+        'email_verified_at' => 'Email Verified At',
+        'plan_type' => 'Plan Type',
+        'subscription_status' => 'Subscription Status',
+        'assessments_count' => 'Assessments Count',
+        'reply' => 'Reply',
+
+        // Guest Session fields
+        'session_id' => 'Session ID',
+        'ip_address' => 'IP Address',
+        'user_agent' => 'User Agent',
+        'device_type' => 'Device Type',
+        'browser' => 'Browser',
+        'browser_version' => 'Browser Version',
+        'operating_system' => 'Operating System',
+        'location' => 'Location',
+        'timezone' => 'Timezone',
+        'isp' => 'ISP',
+        'session_data' => 'Session Data',
+        'last_activity' => 'Last Activity',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Status Values
+    |--------------------------------------------------------------------------
+    */
+    'status' => [
+        'active' => 'Active',
+        'inactive' => 'Inactive',
+        'draft' => 'Draft',
+        'in_progress' => 'In Progress',
+        'completed' => 'Completed',
+        'archived' => 'Archived',
+        'pending' => 'Pending',
+        'approved' => 'Approved',
+        'rejected' => 'Rejected',
+        'expired' => 'Expired',
+        'cancelled' => 'Cancelled',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Plan Types
+    |--------------------------------------------------------------------------
+    */
+    'plans' => [
+        'free' => 'Free',
+        'premium' => 'Premium',
+        'professional' => 'Professional',
+        'enterprise' => 'Enterprise',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Company Types
+    |--------------------------------------------------------------------------
+    */
+    'company_types' => [
+        'commercial' => 'Commercial',
+        'government' => 'Government',
+        'service' => 'Service',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Device Types
+    |--------------------------------------------------------------------------
+    */
+    'device_types' => [
+        'Desktop' => 'Desktop',
+        'Mobile' => 'Mobile',
+        'Tablet' => 'Tablet',
+        'Unknown' => 'Unknown',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Response Values
+    |--------------------------------------------------------------------------
+    */
+    'responses' => [
+        'yes' => 'Yes',
+        'no' => 'No',
+        'na' => 'N/A',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Actions
+    |--------------------------------------------------------------------------
+    */
+    'actions' => [
+        'create' => 'Create',
+        'edit' => 'Edit',
+        'view' => 'View',
+        'delete' => 'Delete',
+        'save' => 'Save',
+        'cancel' => 'Cancel',
+        'search' => 'Search',
+        'filter' => 'Filter',
+        'export' => 'Export',
+        'import' => 'Import',
+        'duplicate' => 'Duplicate',
+        'restore' => 'Restore',
+        'archive' => 'Archive',
+        'activate' => 'Activate',
+        'deactivate' => 'Deactivate',
+        'send_email' => 'Send Email',
+        'download_report' => 'Download Report',
+        'view_details' => 'View Details',
+        'upgrade_to_premium' => 'Upgrade to Premium',
+        'downgrade_to_free' => 'Downgrade to Free',
+        'send_password_reset' => 'Send Password Reset',
+        'toggle_subscription' => 'Toggle Subscription',
+        'contact_user' => 'Contact User',
+        'view_assessment' => 'View Assessment',
+        'view_user_in_admin' => 'View User in Admin',
+        'approve_selected' => 'Approve Selected',
+        'reject_selected' => 'Reject Selected',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Page Titles & Headings
+    |--------------------------------------------------------------------------
+    */
+    'pages' => [
+        'dashboard' => 'Dashboard',
+        'create' => 'Create :resource',
+        'edit' => 'Edit :resource',
+        'view' => 'View :resource',
+        'list' => 'List :resource',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Table Headers & Labels
+    |--------------------------------------------------------------------------
+    */
+    'table' => [
+        'no_records' => 'No records found',
+        'search_placeholder' => 'Search...',
+        'actions' => 'Actions',
+        'bulk_actions' => 'Bulk Actions',
+        'selected_count' => ':count item(s) selected',
+        'per_page' => 'Per Page',
+        'page' => 'Page',
+        'of' => 'of',
+        'results' => 'Results',
+        'showing' => 'Showing',
+        'to' => 'to',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Form Labels & Messages
+    |--------------------------------------------------------------------------
+    */
+    'form' => [
+        'translations' => 'Translations',
+        'english' => 'English',
+        'arabic' => 'Arabic',
+        'basic_information' => 'Basic Information',
+        'contact_details' => 'Contact Details',
+        'subscription_information' => 'Subscription Information',
+        'user_details' => 'User Details',
+        'content' => 'Content',
+        'media_settings' => 'Media & Settings',
+        'seo_meta_data' => 'SEO & Meta Data',
+        'assessment_information' => 'Assessment Information',
+        'session_information' => 'Session Information',
+        'technical_details' => 'Technical Details',
+        'location_information' => 'Location Information',
+        'timestamps' => 'Timestamps',
+        'additional_data' => 'Additional Data',
+        'required_field' => 'Required Field',
+        'optional_field' => 'Optional Field',
+        'select_option' => 'Select Option...',
+        'upload_file' => 'Upload File',
+        'drag_drop_file' => 'Drag & Drop file here or click to browse',
+        'comment_details' => 'Comment Details',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Notifications & Messages
+    |--------------------------------------------------------------------------
+    */
+    'notifications' => [
+        'saved' => 'Saved successfully',
+        'deleted' => 'Deleted successfully',
+        'created' => 'Created successfully',
+        'updated' => 'Updated successfully',
+        'restored' => 'Restored successfully',
+        'error' => 'An error occurred',
+        'success' => 'Operation successful',
+        'warning' => 'Warning',
+        'info' => 'Info',
+        'email_sent' => 'Email sent successfully',
+        'password_reset_sent' => 'Password reset link sent',
+        'user_upgraded' => 'User upgraded to premium',
+        'user_downgraded' => 'User downgraded to free plan',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Filters & Tabs
+    |--------------------------------------------------------------------------
+    */
+    'filters' => [
+        'all' => 'All',
+        'active' => 'Active',
+        'inactive' => 'Inactive',
+        'recent' => 'Recent',
+        'completed' => 'Completed',
+        'in_progress' => 'In Progress',
+        'draft' => 'Draft',
+        'free_users' => 'Free Users',
+        'premium_users' => 'Premium Users',
+        'expired' => 'Expired',
+        'last_24_hours' => 'Last 24 Hours',
+        'last_week' => 'Last Week',
+        'last_month' => 'Last Month',
+        'replies_only' => 'Replies Only',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Widgets & Analytics
+    |--------------------------------------------------------------------------
+    */
+    'widgets' => [
+        'total_sessions' => 'Total Sessions',
+        'unique_users' => 'Unique Users',
+        'completed_assessments' => 'Completed Assessments',
+        'conversion_rate' => 'Conversion Rate',
+        'device_breakdown' => 'Device Breakdown',
+        'geographic_distribution' => 'Geographic Distribution',
+        'sessions_trend' => 'Sessions Trend',
+        'guest_analytics' => 'Guest Analytics',
+        'recent_guest_sessions' => 'Recent Guest Sessions',
+        'increased_by' => 'Increased by',
+        'decreased_by' => 'Decreased by',
+        'sessions_to_completion' => 'Sessions to Completion',
+        'device_usage' => 'Device Usage',
+        'sessions_by_country' => 'Sessions by Country',
+        'total_sessions_chart' => 'Total Sessions',
+        'completed_sessions_chart' => 'Completed Sessions',
+        'last_7_days' => 'Last 7 Days',
+        'last_30_days' => 'Last 30 Days',
+        'last_3_months' => 'Last 3 Months',
+        'this_year' => 'This Year',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Empty States
+    |--------------------------------------------------------------------------
+    */
+    'empty_states' => [
+        'no_tools' => 'No tools found',
+        'no_assessments' => 'No assessments found',
+        'no_users' => 'No users found',
+        'no_sessions' => 'No sessions found',
+        'no_responses' => 'No responses found',
+        'no_records_found' => 'No records found',
+        'start_by_creating' => 'Start by creating a new :resource',
+        'create_first' => 'Create your first :resource',
+    ],
+];


### PR DESCRIPTION
## Summary
- create comprehensive `lang/en/filament.php`
- update Arabic translations with blog and comment labels
- update Filament resources to pull labels from translations
- add new translation keys for blog posts and comments

## Testing
- `phpunit --version` *(fails: command not found)*
- `php artisan test --testsuite Feature` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cc1faabf48331b157a6fd9440fb16