### PR TITLE
Add locale-aware table columns

### DIFF
--- a/app/Filament/Resources/AssessmentResource/RelationManagers/ResponsesRelationManager.php
+++ b/app/Filament/Resources/AssessmentResource/RelationManagers/ResponsesRelationManager.php
@@ -32,16 +32,12 @@ class ResponsesRelationManager extends RelationManager
     public function table(Table $table): Table
     {
         return $table
-            ->recordTitleAttribute('criterion.name_en')
+            ->recordTitleAttribute('criterion.name')
             ->columns([
-                Tables\Columns\TextColumn::make('criterion.name_en')
-                    ->label('Criterion (EN)'),
-                Tables\Columns\TextColumn::make('criterion.name_ar')
-                    ->label('Criterion (AR)'),
-                Tables\Columns\TextColumn::make('criterion.category.name_en')
-                    ->label('Category (EN)'),
-                Tables\Columns\TextColumn::make('criterion.category.name_ar')
-                    ->label('Category (AR)'),
+                Tables\Columns\TextColumn::make('criterion.name')
+                    ->label('Criterion'),
+                Tables\Columns\TextColumn::make('criterion.category.name')
+                    ->label('Category'),
                 Tables\Columns\TextColumn::make('value')
                     ->sortable(),
                 Tables\Columns\TextColumn::make('created_at')

--- a/app/Filament/Resources/AssessmentResponseResource.php
+++ b/app/Filament/Resources/AssessmentResponseResource.php
@@ -56,13 +56,13 @@ class AssessmentResponseResource extends Resource
     {
         return $table
             ->columns([
-                Tables\Columns\TextColumn::make('tool.name_en')
+                Tables\Columns\TextColumn::make('tool.name')
                     ->label(__('filament.resources.assessment.label'))
                     ->sortable(),
-                Tables\Columns\TextColumn::make('criterion.name_en')
+                Tables\Columns\TextColumn::make('criterion.name')
                     ->label(__('filament.fields.criterion'))
                     ->sortable(),
-                Tables\Columns\TextColumn::make('criterion.category.name_en')
+                Tables\Columns\TextColumn::make('criterion.category.name')
                     ->label(__('filament.fields.category'))
                     ->sortable(),
                 Tables\Columns\TextColumn::make('value')

--- a/app/Filament/Resources/BlogPostResource.php
+++ b/app/Filament/Resources/BlogPostResource.php
@@ -186,7 +186,7 @@ class BlogPostResource extends Resource
                     ->size(50),
 
                 Tables\Columns\TextColumn::make('title')
-                    ->searchable()
+                    ->searchable(['title', 'title_ar'])
                     ->sortable()
                     ->limit(50),
 

--- a/app/Filament/Resources/CategoryResource.php
+++ b/app/Filament/Resources/CategoryResource.php
@@ -85,12 +85,12 @@ class CategoryResource extends Resource
     {
         return $table
             ->columns([
-                Tables\Columns\TextColumn::make('domain.name_en')
+                Tables\Columns\TextColumn::make('domain.name')
                     ->label(__('filament.fields.domain'))
                     ->sortable(),
-                Tables\Columns\TextColumn::make('name_en')
-                    ->label(__('filament.fields.name_en'))
-                    ->searchable(),
+                Tables\Columns\TextColumn::make('name')
+                    ->label(__('filament.fields.name'))
+                    ->searchable(['name_en','name_ar']),
                 Tables\Columns\TextColumn::make('order')
                     ->sortable(),
                 Tables\Columns\TextColumn::make('weight_percentage')

--- a/app/Filament/Resources/CategoryResource/RelationManagers/CriteriaRelationManager.php
+++ b/app/Filament/Resources/CategoryResource/RelationManagers/CriteriaRelationManager.php
@@ -58,10 +58,10 @@ class CriteriaRelationManager extends RelationManager
     public function table(Table $table): Table
     {
         return $table
-            ->recordTitleAttribute('name_en')
+            ->recordTitleAttribute('name')
             ->columns([
-                Tables\Columns\TextColumn::make('name_en')
-                    ->label('Name (English)'),
+                Tables\Columns\TextColumn::make('name')
+                    ->label('Name'),
                 Tables\Columns\TextColumn::make('order')
                     ->sortable(),  Tables\Columns\TextColumn::make('weight_percentage'),
                 Tables\Columns\BadgeColumn::make('status')

--- a/app/Filament/Resources/CriterionResource.php
+++ b/app/Filament/Resources/CriterionResource.php
@@ -86,12 +86,12 @@ class CriterionResource extends Resource
     {
         return $table
             ->columns([
-                Tables\Columns\TextColumn::make('category.name_en')
+                Tables\Columns\TextColumn::make('category.name')
                     ->label(__('filament.fields.category'))
                     ->sortable(),
-                Tables\Columns\TextColumn::make('name_en')
-                    ->label(__('filament.fields.name_en'))
-                    ->searchable(),
+                Tables\Columns\TextColumn::make('name')
+                    ->label(__('filament.fields.name'))
+                    ->searchable(['name_en','name_ar']),
                 Tables\Columns\TextColumn::make('order')
                     ->sortable(),
                 Tables\Columns\BadgeColumn::make('status')

--- a/app/Filament/Resources/DomainResource.php
+++ b/app/Filament/Resources/DomainResource.php
@@ -88,12 +88,12 @@ class DomainResource extends Resource
     {
         return $table
             ->columns([
-                Tables\Columns\TextColumn::make('tool.name_en')
+                Tables\Columns\TextColumn::make('tool.name')
                     ->label(__('filament.fields.tool'))
                     ->sortable(),
-                Tables\Columns\TextColumn::make('name_en')
-                    ->label(__('filament.fields.name_en'))
-                    ->searchable(),
+                Tables\Columns\TextColumn::make('name')
+                    ->label(__('filament.fields.name'))
+                    ->searchable(['name_en','name_ar']),
                 Tables\Columns\TextColumn::make('order')
                     ->sortable(),
                 Tables\Columns\TextColumn::make('weight_percentage')

--- a/app/Filament/Resources/DomainResource/RelationManagers/CategoriesRelationManager.php
+++ b/app/Filament/Resources/DomainResource/RelationManagers/CategoriesRelationManager.php
@@ -62,10 +62,10 @@ class CategoriesRelationManager extends RelationManager
     public function table(Table $table): Table
     {
         return $table
-            ->recordTitleAttribute('name_en')
+            ->recordTitleAttribute('name')
             ->columns([
-                Tables\Columns\TextColumn::make('name_en')
-                    ->label('Name (English)'),
+                Tables\Columns\TextColumn::make('name')
+                    ->label('Name'),
                 Tables\Columns\TextColumn::make('order')
                     ->sortable(), Tables\Columns\TextColumn::make('weight_percentage'),
                 Tables\Columns\BadgeColumn::make('status')

--- a/app/Filament/Resources/GuestSessionResource.php
+++ b/app/Filament/Resources/GuestSessionResource.php
@@ -36,7 +36,7 @@ class GuestSessionResource extends Resource
                             ->maxLength(255),
                         Forms\Components\Select::make('assessment_id')
                             ->relationship('assessment', 'id')
-                            ->getOptionLabelFromRecordUsing(fn ($record) => "{$record->tool->name_en} - {$record->name}")
+                            ->getOptionLabelFromRecordUsing(fn ($record) => "{$record->tool->name} - {$record->name}")
                             ->required(),
                     ]),
 
@@ -92,7 +92,7 @@ class GuestSessionResource extends Resource
                 Tables\Columns\TextColumn::make('email')
                     ->searchable()
                     ->sortable(),
-                Tables\Columns\TextColumn::make('assessment.tool.name_en')
+                Tables\Columns\TextColumn::make('assessment.tool.name')
                     ->label('Assessment Tool')
                     ->sortable()
                     ->limit(30),
@@ -198,7 +198,7 @@ class GuestSessionResource extends Resource
                     ->schema([
                         Infolists\Components\TextEntry::make('name'),
                         Infolists\Components\TextEntry::make('email'),
-                        Infolists\Components\TextEntry::make('assessment.tool.name_en')
+                        Infolists\Components\TextEntry::make('assessment.tool.name')
                             ->label('Assessment Tool'),
                         Infolists\Components\TextEntry::make('assessment.organization')
                             ->label('Organization')

--- a/app/Filament/Resources/ToolResource/RelationManagers/DomainRelationManager.php
+++ b/app/Filament/Resources/ToolResource/RelationManagers/DomainRelationManager.php
@@ -60,10 +60,10 @@ class DomainRelationManager extends RelationManager
     public function table(Table $table): Table
     {
         return $table
-            ->recordTitleAttribute('name_en')
+            ->recordTitleAttribute('name')
             ->columns([
-                Tables\Columns\TextColumn::make('name_en')
-                    ->label('Name (English)'),
+                Tables\Columns\TextColumn::make('name')
+                    ->label('Name'),
                 Tables\Columns\TextColumn::make('order')
                     ->sortable(),
                 Tables\Columns\BadgeColumn::make('status')

--- a/app/Models/Assessment.php
+++ b/app/Models/Assessment.php
@@ -119,6 +119,25 @@ class Assessment extends Model
     }
 
     /**
+     * Get localized title for this assessment.
+     */
+    public function getTitle(string $locale = null): string
+    {
+        $locale = $locale ?: app()->getLocale();
+        $field = "title_{$locale}";
+
+        return $this->{$field} ?: $this->tool?->getName($locale);
+    }
+
+    /**
+     * Accessor for localized title attribute.
+     */
+    public function getTitleAttribute(): string
+    {
+        return $this->getTitle();
+    }
+
+    /**
      * Check if this is a guest assessment (no user_id)
      */
     public function isGuestAssessment(): bool

--- a/app/Models/BlogPost.php
+++ b/app/Models/BlogPost.php
@@ -130,4 +130,28 @@ class BlogPost extends Model
         $locale = $locale ?? app()->getLocale();
         return $locale === 'ar' && $this->content_ar ? $this->content_ar : $this->content;
     }
+
+    /**
+     * Accessor for localized title attribute.
+     */
+    public function getTitleAttribute(): string
+    {
+        return $this->getLocalizedTitle();
+    }
+
+    /**
+     * Accessor for localized excerpt attribute.
+     */
+    public function getExcerptAttribute(): string
+    {
+        return $this->getLocalizedExcerpt();
+    }
+
+    /**
+     * Accessor for localized content attribute.
+     */
+    public function getContentAttribute(): string
+    {
+        return $this->getLocalizedContent();
+    }
 }

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -52,6 +52,22 @@ class Category extends Model
         return $this->{$field};
     }
 
+    /**
+     * Accessor for localized name attribute.
+     */
+    public function getNameAttribute(): string
+    {
+        return $this->getName();
+    }
+
+    /**
+     * Accessor for localized description attribute.
+     */
+    public function getDescriptionAttribute(): ?string
+    {
+        return $this->getDescription();
+    }
+
 
     public function calculateScore(array $responses): array
     {

--- a/app/Models/Criterion.php
+++ b/app/Models/Criterion.php
@@ -77,4 +77,20 @@ class Criterion extends Model
 
         return $this->{$field};
     }
+
+    /**
+     * Accessor for localized name attribute.
+     */
+    public function getNameAttribute(): string
+    {
+        return $this->getName();
+    }
+
+    /**
+     * Accessor for localized description attribute.
+     */
+    public function getDescriptionAttribute(): ?string
+    {
+        return $this->getDescription();
+    }
 }

--- a/app/Models/Domain.php
+++ b/app/Models/Domain.php
@@ -51,6 +51,22 @@ class Domain extends Model
         return $this->{$field};
     }
 
+    /**
+     * Accessor for localized name attribute.
+     */
+    public function getNameAttribute(): string
+    {
+        return $this->getName();
+    }
+
+    /**
+     * Accessor for localized description attribute.
+     */
+    public function getDescriptionAttribute(): ?string
+    {
+        return $this->getDescription();
+    }
+
     public function calculateScore(array $responses): array
     {
         $categories = $this->categories;

--- a/app/Models/Tool.php
+++ b/app/Models/Tool.php
@@ -89,6 +89,22 @@ class Tool extends Model
     }
 
     /**
+     * Accessor for localized name attribute.
+     */
+    public function getNameAttribute(): string
+    {
+        return $this->getName();
+    }
+
+    /**
+     * Accessor for localized description attribute.
+     */
+    public function getDescriptionAttribute(): ?string
+    {
+        return $this->getDescription();
+    }
+
+    /**
      * FIXED: Get criteria count using proper relationship counting
      */
     public function getCriteriaCount(): int


### PR DESCRIPTION
## Summary
- add accessor methods to models for localized attributes
- update Filament tables to display the translated names and titles based on the current locale

## Testing
- `composer test` *(fails: composer not available)*

------
https://chatgpt.com/codex/tasks/task_e_686cc979ede483319958cc0fceba32a9