### PR TITLE
Implement blog posts with Filament and React

### DIFF
--- a/app/Filament/Resources/PostResource.php
+++ b/app/Filament/Resources/PostResource.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\PostResource\Pages;
+use App\Filament\Resources\PostResource\RelationManagers\CommentsRelationManager;
+use App\Models\Post;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Illuminate\Support\Str;
+
+class PostResource extends Resource
+{
+    protected static ?string $model = Post::class;
+    protected static ?string $navigationIcon = 'heroicon-o-document-text';
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\TextInput::make('title')
+                    ->required()
+                    ->reactive()
+                    ->afterStateUpdated(fn($state, $set) => $set('slug', Str::slug($state))),
+                Forms\Components\TextInput::make('slug')
+                    ->disabled()
+                    ->required()
+                    ->unique(ignoreRecord: true),
+                Forms\Components\RichEditor::make('content')
+                    ->required()
+                    ->columnSpanFull(),
+                Forms\Components\FileUpload::make('thumbnail')
+                    ->image()
+                    ->directory('thumbnails'),
+                Forms\Components\FileUpload::make('image_gallery')
+                    ->image()
+                    ->multiple()
+                    ->directory('gallery'),
+                Forms\Components\FileUpload::make('audio')
+                    ->acceptedFileTypes(['audio/mpeg','audio/ogg'])
+                    ->directory('audio'),
+                Forms\Components\FileUpload::make('video')
+                    ->acceptedFileTypes(['video/mp4'])
+                    ->directory('video'),
+                Forms\Components\TextInput::make('youtube_url')
+                    ->url()
+                    ->maxLength(255),
+                Forms\Components\DateTimePicker::make('published_at'),
+                Forms\Components\Select::make('status')
+                    ->options([
+                        'draft' => 'Draft',
+                        'published' => 'Published',
+                    ])
+                    ->default('draft')
+                    ->required(),
+            ])->columns(2);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('title')->searchable()->sortable(),
+                Tables\Columns\TextColumn::make('status')->badge(),
+                Tables\Columns\TextColumn::make('published_at')->dateTime(),
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+            ]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            CommentsRelationManager::class,
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ManagePosts::route('/'),
+        ];
+    }
+}

--- a/app/Filament/Resources/PostResource/Pages/ManagePosts.php
+++ b/app/Filament/Resources/PostResource/Pages/ManagePosts.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\PostResource\Pages;
+
+use App\Filament\Resources\PostResource;
+use Filament\Resources\Pages\ManageRecords;
+
+class ManagePosts extends ManageRecords
+{
+    protected static string $resource = PostResource::class;
+}

--- a/app/Filament/Resources/PostResource/RelationManagers/CommentsRelationManager.php
+++ b/app/Filament/Resources/PostResource/RelationManagers/CommentsRelationManager.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Filament\Resources\PostResource\RelationManagers;
+
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class CommentsRelationManager extends RelationManager
+{
+    protected static string $relationship = 'comments';
+
+    public function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\TextInput::make('author_name')->required()->maxLength(255),
+                Forms\Components\Textarea::make('content')->required()->columnSpanFull(),
+            ]);
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('author_name')->sortable()->searchable(),
+                Tables\Columns\TextColumn::make('content')->limit(50),
+                Tables\Columns\TextColumn::make('created_at')->dateTime()->sortable(),
+            ])
+            ->headerActions([
+                Tables\Actions\CreateAction::make(),
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+                Tables\Actions\DeleteAction::make(),
+            ]);
+    }
+}

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Post;
+use App\Models\Comment;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+
+class PostController extends Controller
+{
+    public function show(Post $post)
+    {
+        if ($post->status !== 'published') {
+            abort(404);
+        }
+
+        $comments = $post->comments()->latest()->get();
+
+        return Inertia::render('posts/Show', [
+            'post' => $post,
+            'comments' => $comments,
+        ]);
+    }
+
+    public function storeComment(Request $request, Post $post)
+    {
+        $data = $request->validate([
+            'author_name' => 'required|string|max:255',
+            'content' => 'required|string',
+        ]);
+
+        $post->comments()->create($data);
+
+        return redirect()->back();
+    }
+}

--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Comment extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'post_id',
+        'author_name',
+        'content',
+    ];
+
+    public function post(): BelongsTo
+    {
+        return $this->belongsTo(Post::class);
+    }
+}

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Str;
+
+class Post extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'title',
+        'slug',
+        'content',
+        'thumbnail',
+        'image_gallery',
+        'audio',
+        'video',
+        'youtube_url',
+        'published_at',
+        'status',
+    ];
+
+    protected $casts = [
+        'image_gallery' => 'array',
+        'published_at' => 'datetime',
+    ];
+
+    protected static function booted()
+    {
+        static::creating(function (Post $post) {
+            $post->slug = static::generateUniqueSlug($post->title);
+        });
+    }
+
+    protected static function generateUniqueSlug(string $title): string
+    {
+        $slug = Str::slug($title);
+        $original = $slug;
+        $i = 1;
+        while (static::where('slug', $slug)->exists()) {
+            $slug = "$original-{$i}";
+            $i++;
+        }
+        return $slug;
+    }
+
+    public function comments(): HasMany
+    {
+        return $this->hasMany(Comment::class);
+    }
+}

--- a/database/migrations/2025_07_01_100000_create_posts_table.php
+++ b/database/migrations/2025_07_01_100000_create_posts_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('posts', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->string('slug')->unique();
+            $table->longText('content');
+            $table->string('thumbnail')->nullable();
+            $table->json('image_gallery')->nullable();
+            $table->string('audio')->nullable();
+            $table->string('video')->nullable();
+            $table->string('youtube_url')->nullable();
+            $table->timestamp('published_at')->nullable();
+            $table->enum('status', ['draft', 'published'])->default('draft');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('posts');
+    }
+};

--- a/database/migrations/2025_07_01_100010_create_comments_table.php
+++ b/database/migrations/2025_07_01_100010_create_comments_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('comments', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('post_id')->constrained('posts')->cascadeOnDelete();
+            $table->string('author_name');
+            $table->text('content');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('comments');
+    }
+};

--- a/resources/js/components/post/comment-form.tsx
+++ b/resources/js/components/post/comment-form.tsx
@@ -1,0 +1,58 @@
+import { useState } from 'react';
+import { router } from '@inertiajs/react';
+
+export function CommentForm({ postSlug }: { postSlug: string }) {
+    const [author, setAuthor] = useState('');
+    const [content, setContent] = useState('');
+    const [loading, setLoading] = useState(false);
+
+    const submit = () => {
+        setLoading(true);
+        router.post(
+            `/posts/${postSlug}/comments`,
+            { author_name: author, content },
+            {
+                preserveScroll: true,
+                onFinish: () => {
+                    setAuthor('');
+                    setContent('');
+                    setLoading(false);
+                },
+            }
+        );
+    };
+
+    return (
+        <form
+            onSubmit={(e) => {
+                e.preventDefault();
+                submit();
+            }}
+            className="space-y-2"
+        >
+            <input
+                type="text"
+                value={author}
+                onChange={(e) => setAuthor(e.target.value)}
+                placeholder="Your name"
+                className="w-full rounded border p-2"
+                required
+            />
+            <textarea
+                value={content}
+                onChange={(e) => setContent(e.target.value)}
+                placeholder="Comment"
+                className="w-full rounded border p-2"
+                rows={4}
+                required
+            />
+            <button
+                type="submit"
+                disabled={loading}
+                className="px-4 py-2 bg-blue-600 text-white rounded"
+            >
+                {loading ? 'Posting...' : 'Post Comment'}
+            </button>
+        </form>
+    );
+}

--- a/resources/js/components/post/comment-list.tsx
+++ b/resources/js/components/post/comment-list.tsx
@@ -1,0 +1,17 @@
+import { Comment } from '@/types/post';
+
+export function CommentList({ comments }: { comments: Comment[] }) {
+    return (
+        <div className="space-y-4">
+            {comments.map((c) => (
+                <div key={c.id} className="rounded shadow p-4 bg-white">
+                    <p className="font-semibold">{c.author_name}</p>
+                    <p className="text-sm text-gray-500">
+                        {new Date(c.created_at).toLocaleString()}
+                    </p>
+                    <p className="mt-2 whitespace-pre-wrap">{c.content}</p>
+                </div>
+            ))}
+        </div>
+    );
+}

--- a/resources/js/components/post/post-media.tsx
+++ b/resources/js/components/post/post-media.tsx
@@ -1,0 +1,46 @@
+import { Post } from '@/types/post';
+
+export function PostMedia({ post }: { post: Post }) {
+    return (
+        <div className="space-y-4">
+            {post.thumbnail && (
+                <img
+                    src={post.thumbnail}
+                    alt={post.title}
+                    className="rounded-lg shadow"
+                />
+            )}
+            {post.image_gallery && post.image_gallery.length > 0 && (
+                <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+                    {post.image_gallery.map((img, idx) => (
+                        <img
+                            key={idx}
+                            src={img}
+                            alt={`image-${idx}`}
+                            className="rounded-lg shadow"
+                        />
+                    ))}
+                </div>
+            )}
+            {post.audio && (
+                <audio controls className="w-full">
+                    <source src={post.audio} />
+                </audio>
+            )}
+            {post.video && (
+                <video controls className="w-full rounded-lg shadow">
+                    <source src={post.video} />
+                </video>
+            )}
+            {post.youtube_url && (
+                <div className="aspect-video">
+                    <iframe
+                        src={post.youtube_url}
+                        className="w-full h-full rounded-lg"
+                        allowFullScreen
+                    />
+                </div>
+            )}
+        </div>
+    );
+}

--- a/resources/js/pages/posts/Show.tsx
+++ b/resources/js/pages/posts/Show.tsx
@@ -1,0 +1,41 @@
+import AppLayout from '@/layouts/app-layout';
+import { Post, Comment } from '@/types/post';
+import { Head, router } from '@inertiajs/react';
+import { useState } from 'react';
+import { PostMedia } from '@/components/post/post-media';
+import { CommentForm } from '@/components/post/comment-form';
+import { CommentList } from '@/components/post/comment-list';
+
+interface Props {
+    post: Post;
+    comments: Comment[];
+}
+
+export default function PostShow({ post, comments: initial }: Props) {
+    const [comments, setComments] = useState<Comment[]>(initial);
+
+    const refresh = () => {
+        router.reload({ only: ['comments'] });
+    };
+
+    return (
+        <AppLayout>
+            <Head title={post.title} />
+            <div className="max-w-3xl mx-auto space-y-6 p-4">
+                <h1 className="text-3xl font-bold">{post.title}</h1>
+                {post.published_at && (
+                    <p className="text-gray-500">
+                        {new Date(post.published_at).toLocaleDateString()}
+                    </p>
+                )}
+                <PostMedia post={post} />
+                <div
+                    className="prose max-w-none"
+                    dangerouslySetInnerHTML={{ __html: post.content }}
+                />
+                <CommentForm postSlug={post.slug} />
+                <CommentList comments={comments} />
+            </div>
+        </AppLayout>
+    );
+}

--- a/resources/js/types/post.ts
+++ b/resources/js/types/post.ts
@@ -1,0 +1,21 @@
+export interface Post {
+    id: number;
+    title: string;
+    slug: string;
+    content: string;
+    thumbnail?: string | null;
+    image_gallery?: string[] | null;
+    audio?: string | null;
+    video?: string | null;
+    youtube_url?: string | null;
+    published_at?: string | null;
+    status: 'draft' | 'published';
+}
+
+export interface Comment {
+    id: number;
+    post_id: number;
+    author_name: string;
+    content: string;
+    created_at: string;
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,6 +19,7 @@ use App\Http\Controllers\FreeAssessmentController;
 use App\Http\Controllers\NavigationController;
 use App\Http\Controllers\ToolDiscoveryController;
 use App\Http\Controllers\ToolSubscriptionController;
+use App\Http\Controllers\PostController;
 use App\Models\Tool;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
@@ -84,6 +85,10 @@ Route::post('/contact-sales', [ContactSalesController::class, 'store'])->name('c
 // Guest PDF report generation
 Route::post('/guest/assessments/{assessment}/reports/generate', [AssessmentPDFController::class, 'downloadGuestReport'])
     ->middleware(['throttle:10,1']);
+
+// Blog posts
+Route::get('/posts/{post:slug}', [PostController::class, 'show'])->name('posts.show');
+Route::post('/posts/{post:slug}/comments', [PostController::class, 'storeComment'])->name('posts.comments.store');
 
 // Paddle webhooks (no auth middleware)
 Route::post('/paddle/webhook', [PaddleWebhookController::class, 'handleWebhook'])


### PR DESCRIPTION
## Summary
- create Post and Comment models with migrations
- add Filament resource for managing posts
- add comments relation manager
- add PostController and routes to show posts and accept comments
- build React components and page for displaying posts and handling comments

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run types` *(fails: error TS1149 due to casing conflict)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e291adf108331835104e3cce3d894