### PR TITLE
Add tool access request workflow

### DIFF
--- a/app/Filament/Resources/ToolRequestResource.php
+++ b/app/Filament/Resources/ToolRequestResource.php
@@ -1,0 +1,53 @@
+<?php
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\ToolRequestResource\Pages;
+use App\Models\ToolRequest;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+
+class ToolRequestResource extends Resource
+{
+    protected static ?string $model = ToolRequest::class;
+    protected static ?string $navigationIcon = 'heroicon-o-envelope';
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('name')->searchable(),
+                Tables\Columns\TextColumn::make('email'),
+                Tables\Columns\TextColumn::make('tool.name_en')->label('Tool'),
+                Tables\Columns\TextColumn::make('status')->badge(),
+                Tables\Columns\TextColumn::make('created_at')->dateTime(),
+            ])
+            ->filters([
+                SelectFilter::make('status')
+                    ->options([
+                        'pending' => 'Pending',
+                        'quoted' => 'Quoted',
+                        'done'    => 'Done',
+                    ])
+            ])
+            ->actions([
+                Tables\Actions\ViewAction::make(),
+            ]);
+    }
+
+    public static function form(Form $form): Form
+    {
+        return $form->schema([]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListToolRequests::route('/'),
+            'view' => Pages\ViewToolRequest::route('/{record}'),
+        ];
+    }
+}

--- a/app/Filament/Resources/ToolRequestResource/Pages/ListToolRequests.php
+++ b/app/Filament/Resources/ToolRequestResource/Pages/ListToolRequests.php
@@ -1,0 +1,11 @@
+<?php
+namespace App\Filament\Resources\ToolRequestResource\Pages;
+
+use App\Filament\Resources\ToolRequestResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListToolRequests extends ListRecords
+{
+    protected static string $resource = ToolRequestResource::class;
+}

--- a/app/Filament/Resources/ToolRequestResource/Pages/ViewToolRequest.php
+++ b/app/Filament/Resources/ToolRequestResource/Pages/ViewToolRequest.php
@@ -1,0 +1,63 @@
+<?php
+namespace App\Filament\Resources\ToolRequestResource\Pages;
+
+use App\Filament\Resources\ToolRequestResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ViewRecord;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\Section;
+use Filament\Notifications\Notification;
+use App\Mail\SendToolQuotation;
+use Illuminate\Support\Facades\Mail;
+
+class ViewToolRequest extends ViewRecord
+{
+    protected static string $resource = ToolRequestResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\Action::make('send_quotation')
+                ->label('Send Quotation')
+                ->form([
+                    TextInput::make('amount')
+                        ->numeric()
+                        ->required(),
+                    TextInput::make('bank_name')
+                        ->required(),
+                    TextInput::make('iban')
+                        ->required(),
+                    Textarea::make('note'),
+                ])
+                ->action(function (array $data) {
+                    $record = $this->record;
+                    Mail::to($record->email)->send(new SendToolQuotation($record, $data));
+                    $record->update([
+                        'status' => 'quoted',
+                        'quotation_sent_at' => now(),
+                    ]);
+                    Notification::make()
+                        ->title('Quotation sent')
+                        ->success()
+                        ->send();
+                })
+                ->visible(fn ($record) => $record->status === 'pending'),
+        ];
+    }
+    public function infolist(\Filament\Infolists\Infolist $infolist): \Filament\Infolists\Infolist
+    {
+        return $infolist->schema([
+            \Filament\Infolists\Components\TextEntry::make('name'),
+            \Filament\Infolists\Components\TextEntry::make('email'),
+            \Filament\Infolists\Components\TextEntry::make('organization'),
+            \Filament\Infolists\Components\TextEntry::make('message')->columnSpanFull(),
+            \Filament\Infolists\Components\TextEntry::make('status')->badge(),
+            \Filament\Infolists\Components\TextEntry::make('quotation_sent_at')->dateTime(),
+            \Filament\Infolists\Components\TextEntry::make('tool.name_en')->label('Tool'),
+            \Filament\Infolists\Components\TextEntry::make('created_at')->dateTime(),
+        ]);
+    }
+}

--- a/app/Http/Controllers/ToolRequestController.php
+++ b/app/Http/Controllers/ToolRequestController.php
@@ -1,0 +1,49 @@
+<?php
+namespace App\Http\Controllers;
+
+use App\Http\Requests\StoreToolRequestRequest;
+use App\Models\Tool;
+use App\Models\ToolRequest;
+use App\Models\User;
+use Filament\Notifications\Notification;
+use Illuminate\Http\RedirectResponse;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class ToolRequestController extends Controller
+{
+    public function create(Tool $tool): Response
+    {
+        return Inertia::render('ToolRequestForm', [
+            'tool' => [
+                'id' => $tool->id,
+                'name' => $tool->name_en,
+                'description' => $tool->description_en,
+                'image' => $tool->image,
+            ],
+            'user' => auth()->user() ? [
+                'name' => auth()->user()->name,
+                'email' => auth()->user()->email,
+                'organization' => auth()->user()->getCompanyName(),
+            ] : null,
+        ]);
+    }
+
+    public function store(StoreToolRequestRequest $request): RedirectResponse
+    {
+        $data = $request->validated();
+        $data['user_id'] = auth()->id();
+        $toolRequest = ToolRequest::create($data);
+
+        $admins = User::whereHas('roles', function ($q) {
+            $q->whereIn('name', ['admin', 'super_admin']);
+        })->get();
+
+        Notification::make()
+            ->title('New Tool Request')
+            ->body($toolRequest->name.' requested access to '.$toolRequest->tool->name_en)
+            ->sendToDatabase($admins);
+
+        return redirect()->back()->with('success', 'Request submitted successfully');
+    }
+}

--- a/app/Http/Requests/StoreToolRequestRequest.php
+++ b/app/Http/Requests/StoreToolRequestRequest.php
@@ -1,0 +1,23 @@
+<?php
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreToolRequestRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'tool_id' => ['required', 'integer', 'exists:tools,id'],
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'email', 'max:255'],
+            'organization' => ['nullable', 'string', 'max:255'],
+            'message' => ['nullable', 'string', 'max:2000'],
+        ];
+    }
+}

--- a/app/Mail/SendToolQuotation.php
+++ b/app/Mail/SendToolQuotation.php
@@ -1,0 +1,46 @@
+<?php
+namespace App\Mail;
+
+use App\Models\ToolRequest;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class SendToolQuotation extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public ToolRequest $toolRequest;
+    public array $data;
+
+    public function __construct(ToolRequest $toolRequest, array $data)
+    {
+        $this->toolRequest = $toolRequest;
+        $this->data = $data;
+    }
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: 'Quotation for ' . $this->toolRequest->tool->name_en,
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            markdown: 'emails.tool-quotation',
+            with: [
+                'request' => $this->toolRequest,
+                'data' => $this->data,
+            ]
+        );
+    }
+
+    public function attachments(): array
+    {
+        return [];
+    }
+}

--- a/app/Models/ToolRequest.php
+++ b/app/Models/ToolRequest.php
@@ -1,0 +1,36 @@
+<?php
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ToolRequest extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'tool_id',
+        'name',
+        'email',
+        'organization',
+        'message',
+        'status',
+        'quotation_sent_at',
+    ];
+
+    protected $casts = [
+        'quotation_sent_at' => 'datetime',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function tool(): BelongsTo
+    {
+        return $this->belongsTo(Tool::class);
+    }
+}

--- a/app/Policies/ToolRequestPolicy.php
+++ b/app/Policies/ToolRequestPolicy.php
@@ -1,0 +1,61 @@
+<?php
+namespace App\Policies;
+
+use App\Models\ToolRequest;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class ToolRequestPolicy
+{
+    use HandlesAuthorization;
+
+    public function viewAny(User $user): bool
+    {
+        return $user->can('view_any_tool_request');
+    }
+
+    public function view(User $user, ToolRequest $toolRequest): bool
+    {
+        return $user->can('view_tool_request');
+    }
+
+    public function create(User $user): bool
+    {
+        return $user->can('create_tool_request');
+    }
+
+    public function update(User $user, ToolRequest $toolRequest): bool
+    {
+        return $user->can('update_tool_request');
+    }
+
+    public function delete(User $user, ToolRequest $toolRequest): bool
+    {
+        return $user->can('delete_tool_request');
+    }
+
+    public function deleteAny(User $user): bool
+    {
+        return $user->can('delete_any_tool_request');
+    }
+
+    public function restore(User $user, ToolRequest $toolRequest): bool
+    {
+        return $user->can('restore_tool_request');
+    }
+
+    public function restoreAny(User $user): bool
+    {
+        return $user->can('restore_any_tool_request');
+    }
+
+    public function forceDelete(User $user, ToolRequest $toolRequest): bool
+    {
+        return $user->can('force_delete_tool_request');
+    }
+
+    public function forceDeleteAny(User $user): bool
+    {
+        return $user->can('force_delete_any_tool_request');
+    }
+}

--- a/database/migrations/2025_07_15_000000_create_tool_requests_table.php
+++ b/database/migrations/2025_07_15_000000_create_tool_requests_table.php
@@ -1,0 +1,27 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('tool_requests', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->nullable()->constrained()->nullOnDelete();
+            $table->foreignId('tool_id')->constrained()->cascadeOnDelete();
+            $table->string('name');
+            $table->string('email');
+            $table->string('organization')->nullable();
+            $table->text('message')->nullable();
+            $table->enum('status', ['pending', 'quoted', 'done'])->default('pending');
+            $table->timestamp('quotation_sent_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('tool_requests');
+    }
+};

--- a/resources/js/pages/ToolRequestForm.tsx
+++ b/resources/js/pages/ToolRequestForm.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { Head, useForm, usePage } from '@inertiajs/react';
+import AppLayout from '@/layouts/app-layout';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Button } from '@/components/ui/button';
+import InputError from '@/components/input-error';
+
+interface ToolRequestFormProps {
+    tool: {
+        id: number;
+        name: string;
+        description?: string;
+        image?: string;
+    };
+    user?: {
+        name: string;
+        email: string;
+        organization?: string;
+    } | null;
+}
+
+export default function ToolRequestForm({ tool, user }: ToolRequestFormProps) {
+    const { flash } = usePage().props as any;
+    const { data, setData, post, processing, errors } = useForm({
+        tool_id: tool.id,
+        name: user?.name || '',
+        email: user?.email || '',
+        organization: user?.organization || '',
+        message: '',
+    });
+
+    const submit = (e: React.FormEvent) => {
+        e.preventDefault();
+        post('/tool-requests');
+    };
+
+    return (
+        <AppLayout>
+            <Head title="Request Tool Access" />
+            <div className="max-w-2xl mx-auto p-6 space-y-6">
+                {flash?.success && (
+                    <div className="p-4 bg-green-100 text-green-800 rounded">
+                        {flash.success}
+                    </div>
+                )}
+                <Card>
+                    <CardHeader>
+                        <CardTitle>{tool.name}</CardTitle>
+                    </CardHeader>
+                    {tool.image && (
+                        <img src={tool.image} alt={tool.name} className="w-full h-48 object-cover" />
+                    )}
+                    <CardContent>
+                        <p className="mb-4 text-gray-700">{tool.description}</p>
+                        <form onSubmit={submit} className="space-y-4">
+                            <div className="space-y-2">
+                                <Label htmlFor="name">Full Name</Label>
+                                <Input id="name" value={data.name} onChange={e => setData('name', e.target.value)} required />
+                                <InputError message={errors.name} />
+                            </div>
+                            <div className="space-y-2">
+                                <Label htmlFor="email">Email</Label>
+                                <Input id="email" type="email" value={data.email} onChange={e => setData('email', e.target.value)} required />
+                                <InputError message={errors.email} />
+                            </div>
+                            <div className="space-y-2">
+                                <Label htmlFor="organization">Organization (optional)</Label>
+                                <Input id="organization" value={data.organization} onChange={e => setData('organization', e.target.value)} />
+                                <InputError message={errors.organization} />
+                            </div>
+                            <div className="space-y-2">
+                                <Label htmlFor="message">Message</Label>
+                                <Textarea id="message" value={data.message} onChange={e => setData('message', e.target.value)} rows={4} />
+                                <InputError message={errors.message} />
+                            </div>
+                            <Button type="submit" disabled={processing} className="w-full">
+                                {processing ? 'Submitting...' : 'Submit Request'}
+                            </Button>
+                        </form>
+                    </CardContent>
+                </Card>
+            </div>
+        </AppLayout>
+    );
+}

--- a/resources/js/pages/assessment-tools.tsx
+++ b/resources/js/pages/assessment-tools.tsx
@@ -56,6 +56,7 @@ interface Translations {
         unlimited: string;
         currentUsage: string;
         upgradeNow: string;
+        requestAccess: string;
         freePlan: string;
         premiumPlan: string;
         assessmentLimit: string;
@@ -80,6 +81,7 @@ interface Translations {
         unlimited: string;
         currentUsage: string;
         upgradeNow: string;
+        requestAccess: string;
         freePlan: string;
         premiumPlan: string;
         assessmentLimit: string;
@@ -107,6 +109,7 @@ const translations: Translations = {
         unlimited: "Unlimited",
         currentUsage: "Current Usage",
         upgradeNow: "Upgrade Now",
+        requestAccess: "Request Access",
         freePlan: "Free Plan",
         premiumPlan: "Premium Plan",
         assessmentLimit: "Assessment Limit",
@@ -131,6 +134,7 @@ const translations: Translations = {
         unlimited: "غير محدود",
         currentUsage: "الاستخدام الحالي",
         upgradeNow: "ترقية الآن",
+        requestAccess: "طلب الوصول",
         freePlan: "الخطة المجانية",
         premiumPlan: "الخطة المدفوعة",
         assessmentLimit: "حد التقييمات",
@@ -209,7 +213,7 @@ export default function AssessmentTools({ tools, userLimits, locale }: Assessmen
                                 userLimits.can_create_more &&
                                 tool.status === 'active' &&
                                 tool.has_access;
-                            const canStart = userLimits.can_create_more && tool.status === 'active';
+                            const showRequest = tool.status === 'active' && !tool.has_access;
                             return (
                                 <Card key={tool.id} className="flex flex-col overflow-hidden">
                                     {tool.image && (
@@ -226,6 +230,12 @@ export default function AssessmentTools({ tools, userLimits, locale }: Assessmen
                                                     <Button className="w-full">
                                                         <Play className="w-4 h-4 mr-2" />
                                                         {t.startAssessment}
+                                                    </Button>
+                                                </Link>
+                                            ) : showRequest ? (
+                                                <Link href={`/tools/request/${tool.id}`}>
+                                                    <Button variant="secondary" className="w-full">
+                                                        {t.requestAccess}
                                                     </Button>
                                                 </Link>
                                             ) : (

--- a/resources/views/emails/tool-quotation.blade.php
+++ b/resources/views/emails/tool-quotation.blade.php
@@ -1,0 +1,24 @@
+@component('mail::message')
+# Quotation for {{ $request->tool->name_en }}
+
+Dear {{ $request->name }},
+
+Thank you for your interest in {{ $request->tool->name_en }}. Below are the quotation details:
+
+@component('mail::panel')
+**Amount:** {{ $data['amount'] }}
+
+**Bank:** {{ $data['bank_name'] }}
+
+**IBAN:** {{ $data['iban'] }}
+@endcomponent
+
+@if(!empty($data['note']))
+{{ $data['note'] }}
+@endif
+
+If you have any questions, feel free to reply to this email.
+
+Thanks,
+{{ config('app.name') }} Team
+@endcomponent

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,6 +19,7 @@ use App\Http\Controllers\FreeAssessmentController;
 use App\Http\Controllers\NavigationController;
 use App\Http\Controllers\ToolDiscoveryController;
 use App\Http\Controllers\ToolSubscriptionController;
+use App\Http\Controllers\ToolRequestController;
 use App\Http\Controllers\PostController;
 use App\Models\Tool;
 use Illuminate\Support\Facades\Route;
@@ -81,6 +82,10 @@ Route::post('/user/register-free', [UserRegistrationController::class, 'register
 
 // Contact sales
 Route::post('/contact-sales', [ContactSalesController::class, 'store'])->name('contact.sales');
+
+// Tool access requests
+Route::get('/tools/request/{tool}', [ToolRequestController::class, 'create'])->name('tool-request.create');
+Route::post('/tool-requests', [ToolRequestController::class, 'store'])->name('tool-request.store');
 
 // Guest PDF report generation
 Route::post('/guest/assessments/{assessment}/reports/generate', [AssessmentPDFController::class, 'downloadGuestReport'])


### PR DESCRIPTION
## Summary
- create ToolRequest model, policy, and migration
- add controller and Inertia form page for requesting tool access
- integrate request access button on assessment tools page
- create Filament resource with quotation action
- send styled email when quoting a request
- expose new routes

## Testing
- `npm test` *(fails: Missing script)*
- `phpunit` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686e581b21f08331bfdef8018d2943b8