### PR TITLE
Add black and white style for tool pages

### DIFF
--- a/resources/js/pages/ToolRequestForm.tsx
+++ b/resources/js/pages/ToolRequestForm.tsx
@@ -40,48 +40,74 @@ export default function ToolRequestForm({ tool, user }: ToolRequestFormProps) {
     return (
         <AppLayout>
             <Head title="Request Tool Access" />
-            <div className="max-w-2xl mx-auto p-6 space-y-6">
-                {flash?.success && (
-                    <div className="p-4 bg-green-100 text-green-800 rounded">
-                        {flash.success}
-                    </div>
-                )}
-                <Card>
-                    <CardHeader>
-                        <CardTitle>{tool.name}</CardTitle>
-                    </CardHeader>
-                    {tool.image && (
-                        <img src={tool.image} alt={tool.name} className="w-full h-48 object-cover" />
+            <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-black via-gray-800 to-gray-900 p-6 text-white">
+                <div className="w-full max-w-xl space-y-6">
+                    {flash?.success && (
+                        <div className="p-4 bg-green-600/20 text-green-300 rounded">
+                            {flash.success}
+                        </div>
                     )}
-                    <CardContent>
-                        <p className="mb-4 text-gray-700">{tool.description}</p>
-                        <form onSubmit={submit} className="space-y-4">
-                            <div className="space-y-2">
-                                <Label htmlFor="name">Full Name</Label>
-                                <Input id="name" value={data.name} onChange={e => setData('name', e.target.value)} required />
-                                <InputError message={errors.name} />
-                            </div>
-                            <div className="space-y-2">
-                                <Label htmlFor="email">Email</Label>
-                                <Input id="email" type="email" value={data.email} onChange={e => setData('email', e.target.value)} required />
-                                <InputError message={errors.email} />
-                            </div>
-                            <div className="space-y-2">
-                                <Label htmlFor="organization">Organization (optional)</Label>
-                                <Input id="organization" value={data.organization} onChange={e => setData('organization', e.target.value)} />
-                                <InputError message={errors.organization} />
-                            </div>
-                            <div className="space-y-2">
-                                <Label htmlFor="message">Message</Label>
-                                <Textarea id="message" value={data.message} onChange={e => setData('message', e.target.value)} rows={4} />
-                                <InputError message={errors.message} />
-                            </div>
-                            <Button type="submit" disabled={processing} className="w-full">
-                                {processing ? 'Submitting...' : 'Submit Request'}
-                            </Button>
-                        </form>
-                    </CardContent>
-                </Card>
+                    <Card className="bg-white text-black shadow-lg">
+                        <CardHeader>
+                            <CardTitle className="text-2xl font-semibold">{tool.name}</CardTitle>
+                        </CardHeader>
+                        {tool.image && (
+                            <img src={tool.image} alt={tool.name} className="w-full h-48 object-cover" />
+                        )}
+                        <CardContent>
+                            <p className="mb-4 text-gray-700">{tool.description}</p>
+                            <form onSubmit={submit} className="space-y-4">
+                                <div className="space-y-1">
+                                    <Label htmlFor="name">Full Name</Label>
+                                    <Input
+                                        id="name"
+                                        value={data.name}
+                                        onChange={(e) => setData('name', e.target.value)}
+                                        required
+                                        className="bg-gray-100"
+                                    />
+                                    <InputError message={errors.name} />
+                                </div>
+                                <div className="space-y-1">
+                                    <Label htmlFor="email">Email</Label>
+                                    <Input
+                                        id="email"
+                                        type="email"
+                                        value={data.email}
+                                        onChange={(e) => setData('email', e.target.value)}
+                                        required
+                                        className="bg-gray-100"
+                                    />
+                                    <InputError message={errors.email} />
+                                </div>
+                                <div className="space-y-1">
+                                    <Label htmlFor="organization">Organization (optional)</Label>
+                                    <Input
+                                        id="organization"
+                                        value={data.organization}
+                                        onChange={(e) => setData('organization', e.target.value)}
+                                        className="bg-gray-100"
+                                    />
+                                    <InputError message={errors.organization} />
+                                </div>
+                                <div className="space-y-1">
+                                    <Label htmlFor="message">Message</Label>
+                                    <Textarea
+                                        id="message"
+                                        value={data.message}
+                                        onChange={(e) => setData('message', e.target.value)}
+                                        rows={4}
+                                        className="bg-gray-100"
+                                    />
+                                    <InputError message={errors.message} />
+                                </div>
+                                <Button type="submit" disabled={processing} className="w-full bg-black text-white hover:bg-gray-800">
+                                    {processing ? 'Submitting...' : 'Submit Request'}
+                                </Button>
+                            </form>
+                        </CardContent>
+                    </Card>
+                </div>
             </div>
         </AppLayout>
     );

--- a/resources/js/pages/assessment-tools.tsx
+++ b/resources/js/pages/assessment-tools.tsx
@@ -169,13 +169,16 @@ export default function AssessmentTools({ tools, userLimits, locale }: Assessmen
     return (
         <AppLayout breadcrumbs={breadcrumbs}>
             <Head title={t.title} />
-            <div className={`${language === 'ar' ? 'rtl' : 'ltr'} p-6`} dir={language === 'ar' ? 'rtl' : 'ltr'}>
+            <div
+                className={`${language === 'ar' ? 'rtl' : 'ltr'} min-h-screen bg-gradient-to-br from-black via-gray-900 to-gray-800 p-6 text-white`}
+                dir={language === 'ar' ? 'rtl' : 'ltr'}
+            >
                 <div className="flex items-center justify-between mb-6">
                     <h1 className="text-3xl font-bold flex items-center gap-2">
-                        <Target className="w-6 h-6 text-blue-600" />
+                        <Target className="w-6 h-6 text-white" />
                         {t.title}
                     </h1>
-                    <Button variant="outline" size="sm" onClick={toggleLanguage}>
+                    <Button variant="outline" size="sm" onClick={toggleLanguage} className="border-white text-white hover:bg-white hover:text-black">
                         <Globe className="w-4 h-4 mr-1" />
                         {language === 'en' ? 'عربي' : 'English'}
                     </Button>
@@ -187,7 +190,7 @@ export default function AssessmentTools({ tools, userLimits, locale }: Assessmen
                         placeholder={t.searchPlaceholder}
                         value={searchTerm}
                         onChange={(e) => setSearchTerm(e.target.value)}
-                        className="pl-10"
+                        className="pl-10 bg-gray-800 text-white border-gray-700"
                     />
                 </div>
 
@@ -201,7 +204,7 @@ export default function AssessmentTools({ tools, userLimits, locale }: Assessmen
 
                             const showRequest = tool.status === 'active' && !tool.has_access;
                             return (
-                                <Card key={tool.id} className="flex flex-col overflow-hidden shadow-md">
+                                <Card key={tool.id} className="flex flex-col overflow-hidden shadow-md bg-white text-black">
                                     {tool.image && (
                                         <img
                                             src={tool.image}

--- a/resources/js/pages/assessments/index.tsx
+++ b/resources/js/pages/assessments/index.tsx
@@ -111,12 +111,20 @@ export default function AssessmentsIndex({ assessments, locale, auth }: Assessme
         <AppLayout breadcrumbs={breadcrumbs}>
             <Head title={t.title} />
 
-            <div className={`${language === 'ar' ? 'rtl' : 'ltr'} p-6`} dir={language === 'ar' ? 'rtl' : 'ltr'}>
+            <div
+                className={`${language === 'ar' ? 'rtl' : 'ltr'} min-h-screen bg-gradient-to-br from-black via-gray-900 to-gray-800 p-6 text-white`}
+                dir={language === 'ar' ? 'rtl' : 'ltr'}
+            >
                 <div className="flex items-center justify-between mb-4">
                     <h1 className="text-2xl font-bold flex items-center gap-2">
-                        <Award className="w-5 h-5 text-primary" /> {t.title}
+                        <Award className="w-5 h-5 text-white" /> {t.title}
                     </h1>
-                    <Button variant="outline" size="sm" onClick={toggleLanguage} className="flex items-center gap-2">
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={toggleLanguage}
+                        className="flex items-center gap-2 border-white text-white hover:bg-white hover:text-black"
+                    >
                         <Globe className="w-4 h-4" />
                         <span>{language === 'en' ? 'عربي' : 'English'}</span>
                     </Button>
@@ -128,7 +136,7 @@ export default function AssessmentsIndex({ assessments, locale, auth }: Assessme
                         placeholder={t.searchPlaceholder}
                         value={searchTerm}
                         onChange={(e) => setSearchTerm(e.target.value)}
-                        className="pl-9"
+                        className="pl-9 bg-gray-800 text-white border-gray-700"
                     />
                 </div>
 
@@ -138,7 +146,7 @@ export default function AssessmentsIndex({ assessments, locale, auth }: Assessme
                             const isComplete = a.status === 'completed';
                             const url = isComplete ? resultsUrl(a) : continueUrl(a);
                             return (
-                                <Card key={a.id} className="flex flex-col overflow-hidden">
+                                <Card key={a.id} className="flex flex-col overflow-hidden bg-white text-black">
                                     {a.tool.image && (
                                         <img
                                             src={a.tool.image}


### PR DESCRIPTION
## Summary
- redesign ToolRequestForm with black/white theme and auto-filled editable user info
- modernize assessment-tools and My Assessments pages with the same style

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm run types` *(fails: TS1149 duplicate file name casing)*
- `composer test` *(fails: This database driver does not support fulltext index creation)*

------
https://chatgpt.com/codex/tasks/task_e_68728be80ef88331b954a60f1d413129