### PR TITLE
Centralize language switching

### DIFF
--- a/resources/js/app.tsx
+++ b/resources/js/app.tsx
@@ -6,6 +6,7 @@ import { createRoot } from 'react-dom/client';
 import { initializeTheme } from './hooks/use-appearance';
 // 👇 UPDATED IMPORT - Note the .tsx extension
 import { ToastProvider } from './components/ui/use-toast';
+import { LanguageProvider } from './hooks/use-language';
 
 const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
 
@@ -19,7 +20,9 @@ createInertiaApp({
         // 👇 WRAP THE APP WITH TOAST PROVIDER
         root.render(
             <ToastProvider>
-                <App {...props} />
+                <LanguageProvider>
+                    <App {...props} />
+                </LanguageProvider>
             </ToastProvider>
         );
     },

--- a/resources/js/components/app-sidebar-header.tsx
+++ b/resources/js/components/app-sidebar-header.tsx
@@ -1,5 +1,6 @@
 import { Breadcrumbs } from '@/components/breadcrumbs';
 import { SidebarTrigger } from '@/components/ui/sidebar';
+import { LanguageSwitch } from '@/components/language-switch';
 import { type BreadcrumbItem as BreadcrumbItemType } from '@/types';
 
 export function AppSidebarHeader({ breadcrumbs = [] }: { breadcrumbs?: BreadcrumbItemType[] }) {
@@ -8,6 +9,9 @@ export function AppSidebarHeader({ breadcrumbs = [] }: { breadcrumbs?: Breadcrum
             <div className="flex items-center gap-2">
                 <SidebarTrigger className="-ml-1" />
                 <Breadcrumbs breadcrumbs={breadcrumbs} />
+            </div>
+            <div className="ml-auto">
+                <LanguageSwitch />
             </div>
         </header>
     );

--- a/resources/js/components/app-sidebar.tsx
+++ b/resources/js/components/app-sidebar.tsx
@@ -6,39 +6,38 @@ import { type NavItem } from '@/types';
 import { Link } from '@inertiajs/react';
 import { BookOpen, Folder, LayoutGrid  , FileText, ClipboardCheck} from 'lucide-react';
 import AppLogo from './app-logo';
+import { useLanguage } from '@/hooks/use-language';
 
-const mainNavItems: NavItem[] = [
-    {
-        title: 'Dashboard',
-        href: '/dashboard',
-        icon: LayoutGrid,
+const translations = {
+    en: {
+        dashboard: 'Dashboard',
+        tools: 'Assessment Tools',
+        assessments: 'My Assessments',
+        repository: 'Repository',
+        documentation: 'Documentation',
     },
-    {
-        title: 'Assessment Tools',
-        href: '/assessment-tools',
-        icon: ClipboardCheck,
+    ar: {
+        dashboard: 'لوحة التحكم',
+        tools: 'أدوات التقييم',
+        assessments: 'تقييماتي',
+        repository: 'المستودع',
+        documentation: 'التوثيق',
     },
-    {
-        title: 'My Assessments',
-        href: '/assessments',
-        icon: FileText,
-    }
-];
-
-const footerNavItems: NavItem[] = [
-    {
-        title: 'Repository',
-        href: 'https://github.com/laravel/react-starter-kit',
-        icon: Folder,
-    },
-    {
-        title: 'Documentation',
-        href: 'https://laravel.com/docs/starter-kits#react',
-        icon: BookOpen,
-    }
-];
-
+};
 export function AppSidebar() {
+    const { language } = useLanguage();
+    const t = translations[language];
+
+    const mainNavItems: NavItem[] = [
+        { title: t.dashboard, href: '/dashboard', icon: LayoutGrid },
+        { title: t.tools, href: '/assessment-tools', icon: ClipboardCheck },
+        { title: t.assessments, href: '/assessments', icon: FileText },
+    ];
+
+    const footerNavItems: NavItem[] = [
+        { title: t.repository, href: 'https://github.com/laravel/react-starter-kit', icon: Folder },
+        { title: t.documentation, href: 'https://laravel.com/docs/starter-kits#react', icon: BookOpen },
+    ];
     return (
         <Sidebar collapsible="icon" variant="inset">
             <SidebarHeader>

--- a/resources/js/components/language-switch.tsx
+++ b/resources/js/components/language-switch.tsx
@@ -1,0 +1,19 @@
+import { Button } from '@/components/ui/button';
+import { useLanguage } from '@/hooks/use-language';
+import { Globe } from 'lucide-react';
+
+export function LanguageSwitch({ className }: { className?: string }) {
+    const { language, toggleLanguage } = useLanguage();
+
+    return (
+        <Button
+            variant="outline"
+            size="sm"
+            onClick={toggleLanguage}
+            className={className}
+        >
+            <Globe className="w-4 h-4 mr-1" />
+            <span>{language === 'en' ? 'عربي' : 'English'}</span>
+        </Button>
+    );
+}

--- a/resources/js/components/nav-main.tsx
+++ b/resources/js/components/nav-main.tsx
@@ -1,12 +1,19 @@
 import { SidebarGroup, SidebarGroupLabel, SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar';
 import { type NavItem } from '@/types';
 import { Link, usePage } from '@inertiajs/react';
+import { useLanguage } from '@/hooks/use-language';
+
+const labels = {
+    en: 'Platform',
+    ar: 'المنصة',
+};
 
 export function NavMain({ items = [] }: { items: NavItem[] }) {
     const page = usePage();
+    const { language } = useLanguage();
     return (
         <SidebarGroup className="px-2 py-0">
-            <SidebarGroupLabel>Platform</SidebarGroupLabel>
+            <SidebarGroupLabel>{labels[language]}</SidebarGroupLabel>
             <SidebarMenu>
                 {items.map((item) => (
                     <SidebarMenuItem key={item.title}>

--- a/resources/js/hooks/use-language.tsx
+++ b/resources/js/hooks/use-language.tsx
@@ -1,0 +1,83 @@
+import React, { useCallback, useEffect, useState } from 'react';
+
+export type Language = 'en' | 'ar';
+
+interface LanguageContextValue {
+    language: Language;
+    setLanguage: (lang: Language) => void;
+    toggleLanguage: () => void;
+}
+
+const LanguageContext = React.createContext<LanguageContextValue | null>(null);
+
+const getStoredLanguage = (): Language => {
+    if (typeof window === 'undefined') return 'en';
+
+    const stored = localStorage.getItem('language') as Language | null;
+    if (stored === 'en' || stored === 'ar') {
+        return stored;
+    }
+
+    const cookie = document.cookie
+        .split(';')
+        .find(c => c.trim().startsWith('language='));
+    if (cookie) {
+        const value = cookie.split('=')[1] as Language;
+        if (value === 'en' || value === 'ar') {
+            return value;
+        }
+    }
+
+    const htmlLang = document.documentElement.lang as Language;
+    if (htmlLang === 'en' || htmlLang === 'ar') {
+        return htmlLang;
+    }
+
+    return 'en';
+};
+
+const applyLanguage = (lang: Language) => {
+    if (typeof document === 'undefined') return;
+    document.documentElement.lang = lang;
+    document.documentElement.dir = lang === 'ar' ? 'rtl' : 'ltr';
+};
+
+export function LanguageProvider({ children }: { children: React.ReactNode }) {
+    const [language, setLanguageState] = useState<Language>('en');
+
+    useEffect(() => {
+        const initial = getStoredLanguage();
+        setLanguageState(initial);
+        applyLanguage(initial);
+    }, []);
+
+    const setLanguage = useCallback((lang: Language) => {
+        setLanguageState(lang);
+        if (typeof window !== 'undefined') {
+            localStorage.setItem('language', lang);
+        }
+        if (typeof document !== 'undefined') {
+            document.cookie = `language=${lang};path=/;max-age=31536000;SameSite=Lax`;
+        }
+    }, []);
+
+    useEffect(() => {
+        applyLanguage(language);
+    }, [language]);
+
+    const toggleLanguage = useCallback(() => {
+        setLanguage(language === 'en' ? 'ar' : 'en');
+    }, [language, setLanguage]);
+
+    return (
+        <LanguageContext.Provider value={{ language, setLanguage, toggleLanguage }}>
+            {children}
+        </LanguageContext.Provider>
+    );
+}
+
+export function useLanguage() {
+    const ctx = React.useContext(LanguageContext);
+    if (!ctx) throw new Error('useLanguage must be used within a LanguageProvider');
+    return ctx;
+}

--- a/resources/js/pages/FreeAssessment/Edit.tsx
+++ b/resources/js/pages/FreeAssessment/Edit.tsx
@@ -22,6 +22,7 @@ import {
     Clock,
     Users
 } from 'lucide-react';
+import { useLanguage } from '@/hooks/use-language';
 
 interface Criterion {
     id: number;
@@ -104,7 +105,7 @@ export default function Start({ assessmentData, locale, auth, existingNotes }: T
     );
     const [notes, setNotes] = useState<Record<number, string>>(existingNotes || {});
     const [files, setFiles] = useState<Record<number, File | null>>({});
-    const [language, setLanguage] = useState<'en' | 'ar'>(locale === 'ar' ? 'ar' : 'en');
+    const { language } = useLanguage();
     const [showScrollTop, setShowScrollTop] = useState(false);
 
     // Form for submission
@@ -273,9 +274,6 @@ export default function Start({ assessmentData, locale, auth, existingNotes }: T
         window.scrollTo({ top: 0, behavior: 'smooth' });
     };
 
-    const toggleLanguage = () => {
-        setLanguage(prev => prev === 'en' ? 'ar' : 'en');
-    };
 
     return (
         <>
@@ -313,14 +311,7 @@ export default function Start({ assessmentData, locale, auth, existingNotes }: T
                                     </div>
                                     <Progress value={completionPercentage} className="w-24 h-2" />
                                 </div>
-                                <Button
-                                    variant="outline"
-                                    size="sm"
-                                    onClick={toggleLanguage}
-                                    className="border-blue-200 hover:bg-blue-50"
-                                >
-                                    {language === 'en' ? 'عربي' : 'English'}
-                                </Button>
+
                             </div>
                         </div>
                     </div>

--- a/resources/js/pages/FreeAssessment/Results.tsx
+++ b/resources/js/pages/FreeAssessment/Results.tsx
@@ -19,6 +19,7 @@ import {
     Calendar,
     Share2
 } from 'lucide-react';
+import { useLanguage } from '@/hooks/use-language';
 
 interface Assessment {
     id: number;
@@ -64,8 +65,8 @@ interface ResultsProps {
 }
 
 export default function Results({ assessment, statistics, domainScores, user, canEdit, locale }: ResultsProps) {
-    const [language, setLanguage] = useState<'en' | 'ar'>(locale === 'ar' ? 'ar' : 'en');
-    const isArabic = locale === 'ar';
+    const { language } = useLanguage();
+    const isArabic = language === 'ar';
 
     const getScoreGrade = (score: number) => {
         if (score >= 90) return { grade: 'A+', color: 'text-green-600', bg: 'bg-green-100' };

--- a/resources/js/pages/FreeAssessment/Start.tsx
+++ b/resources/js/pages/FreeAssessment/Start.tsx
@@ -22,6 +22,7 @@ import {
     Clock,
     Users
 } from 'lucide-react';
+import { useLanguage } from '@/hooks/use-language';
 
 interface Criterion {
     id: number;
@@ -104,7 +105,7 @@ export default function Start({ assessmentData, locale, auth, existingNotes }: T
     );
     const [notes, setNotes] = useState<Record<number, string>>(existingNotes || {});
     const [files, setFiles] = useState<Record<number, File | null>>({});
-    const [language, setLanguage] = useState<'en' | 'ar'>(locale === 'ar' ? 'ar' : 'en');
+    const { language } = useLanguage();
     const [showScrollTop, setShowScrollTop] = useState(false);
 
     // Form for submission
@@ -266,9 +267,6 @@ export default function Start({ assessmentData, locale, auth, existingNotes }: T
         window.scrollTo({ top: 0, behavior: 'smooth' });
     };
 
-    const toggleLanguage = () => {
-        setLanguage(prev => prev === 'en' ? 'ar' : 'en');
-    };
 
     return (
         <>
@@ -306,14 +304,7 @@ export default function Start({ assessmentData, locale, auth, existingNotes }: T
                                     </div>
                                     <Progress value={completionPercentage} className="w-24 h-2" />
                                 </div>
-                                <Button
-                                    variant="outline"
-                                    size="sm"
-                                    onClick={toggleLanguage}
-                                    className="border-blue-200 hover:bg-blue-50"
-                                >
-                                    {language === 'en' ? 'عربي' : 'English'}
-                                </Button>
+
                             </div>
                         </div>
                     </div>

--- a/resources/js/pages/assessment-tools.tsx
+++ b/resources/js/pages/assessment-tools.tsx
@@ -9,9 +9,9 @@ import {
     Search,
     Play,
     Target,
-    Globe,
     Lock
 } from 'lucide-react';
+import { useLanguage } from '@/hooks/use-language';
 
 interface Tool {
     id: number;
@@ -38,7 +38,6 @@ interface UserLimits {
 interface AssessmentToolsProps {
     tools: Tool[];
     userLimits: UserLimits;
-    locale: string;
 }
 
 
@@ -146,14 +145,10 @@ const breadcrumbs: BreadcrumbItem[] = [
     },
 ];
 
-export default function AssessmentTools({ tools, userLimits, locale }: AssessmentToolsProps) {
+export default function AssessmentTools({ tools, userLimits }: AssessmentToolsProps) {
     const [searchTerm, setSearchTerm] = useState('');
-    const [language, setLanguage] = useState<'en' | 'ar'>(locale === 'ar' ? 'ar' : 'en');
+    const { language } = useLanguage();
     const t = translations[language];
-
-    const toggleLanguage = () => {
-        setLanguage((prev) => (prev === 'en' ? 'ar' : 'en'));
-    };
 
     const getText = (tool: Tool, field: 'name' | 'description') => {
         const en = field === 'name' ? tool.name_en : tool.description_en;
@@ -175,10 +170,6 @@ export default function AssessmentTools({ tools, userLimits, locale }: Assessmen
                         <Target className="w-6 h-6 text-blue-600" />
                         {t.title}
                     </h1>
-                    <Button variant="outline" size="sm" onClick={toggleLanguage}>
-                        <Globe className="w-4 h-4 mr-1" />
-                        {language === 'en' ? 'عربي' : 'English'}
-                    </Button>
                 </div>
 
                 <div className="relative mb-8 max-w-md">

--- a/resources/js/pages/assessment/Take.tsx
+++ b/resources/js/pages/assessment/Take.tsx
@@ -22,6 +22,7 @@ import {
     Clock,
     Users
 } from 'lucide-react';
+import { useLanguage } from '@/hooks/use-language';
 
 interface Criterion {
     id: number;
@@ -70,7 +71,6 @@ interface AssessmentData {
 
 interface TakeProps {
     assessmentData: AssessmentData;
-    locale: string;
     auth: {
         user: {
             id: number;
@@ -80,11 +80,11 @@ interface TakeProps {
     };
 }
 
-export default function Take({ assessmentData, locale, auth }: TakeProps) {
+export default function Take({ assessmentData, auth }: TakeProps) {
     const [responses, setResponses] = useState<Record<number, 'yes' | 'no' | 'na'>>({});
     const [notes, setNotes] = useState<Record<number, string>>({});
     const [files, setFiles] = useState<Record<number, File | null>>({});
-    const [language, setLanguage] = useState<'en' | 'ar'>(locale === 'ar' ? 'ar' : 'en');
+    const { language } = useLanguage();
     const [showScrollTop, setShowScrollTop] = useState(false);
 
     // Form for submission
@@ -252,9 +252,6 @@ export default function Take({ assessmentData, locale, auth }: TakeProps) {
         window.scrollTo({ top: 0, behavior: 'smooth' });
     };
 
-    const toggleLanguage = () => {
-        setLanguage(prev => prev === 'en' ? 'ar' : 'en');
-    };
 
     return (
         <>
@@ -292,14 +289,6 @@ export default function Take({ assessmentData, locale, auth }: TakeProps) {
                                     </div>
                                     <Progress value={completionPercentage} className="w-24 h-2" />
                                 </div>
-                                <Button
-                                    variant="outline"
-                                    size="sm"
-                                    onClick={toggleLanguage}
-                                    className="border-blue-200 hover:bg-blue-50"
-                                >
-                                    {language === 'en' ? 'عربي' : 'English'}
-                                </Button>
                             </div>
                         </div>
                     </div>

--- a/resources/js/pages/assessment/results.tsx
+++ b/resources/js/pages/assessment/results.tsx
@@ -30,6 +30,7 @@ import {
     Crown
 } from 'lucide-react';
 import PDFGeneratorComponent from '@/components/PDFGeneratorComponent';
+import { useLanguage } from '@/hooks/use-language';
 
 // Language text content
 const content = {
@@ -165,38 +166,6 @@ interface AssessmentResults {
     category_results: Record<string, CategoryResult[]>;
 }
 
-// Language Toggle Component
-const LanguageToggle: React.FC<{
-    currentLang: 'en' | 'ar';
-    onLanguageChange: (lang: 'en' | 'ar') => void;
-}> = ({ currentLang, onLanguageChange }) => {
-    return (
-        <div className="relative">
-            <div className="flex items-center bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden">
-                <button
-                    onClick={() => onLanguageChange('en')}
-                    className={`px-4 py-2 text-sm font-medium transition-all duration-200 ${
-                        currentLang === 'en'
-                            ? 'bg-blue-600 text-white shadow-sm'
-                            : 'text-gray-600 hover:bg-gray-50'
-                    }`}
-                >
-                    English
-                </button>
-                <button
-                    onClick={() => onLanguageChange('ar')}
-                    className={`px-4 py-2 text-sm font-medium transition-all duration-200 ${
-                        currentLang === 'ar'
-                            ? 'bg-blue-600 text-white shadow-sm'
-                            : 'text-gray-600 hover:bg-gray-50'
-                    }`}
-                >
-                    عربي
-                </button>
-            </div>
-        </div>
-    );
-};
 
 // Enhanced Circular Progress Component
 const CircularProgress: React.FC<{
@@ -396,7 +365,7 @@ export default function AssessmentResults({
                                               locale = 'en',
                                               isGuest = false
                                           }: AssessmentResultsProps) {
-    const [language, setLanguage] = useState<'en' | 'ar'>(locale === 'ar' ? 'ar' : 'en');
+    const { language } = useLanguage();
     const isArabic = language === 'ar';
     const t = content[language];
 
@@ -500,10 +469,6 @@ export default function AssessmentResults({
                             </div>
 
                             <div className="flex items-center gap-4">
-                                <LanguageToggle
-                                    currentLang={language}
-                                    onLanguageChange={setLanguage}
-                                />
                                 <Button variant="outline" size="sm">
                                     <Share2 className="h-4 w-4 mr-2" />
                                     {t.share}

--- a/resources/js/pages/assessment/start.tsx
+++ b/resources/js/pages/assessment/start.tsx
@@ -9,7 +9,6 @@ import { Textarea } from '@/components/ui/textarea';
 import { Badge } from '@/components/ui/badge';
 import { Progress } from '@/components/ui/progress';
 import {
-    Globe,
     User,
     Mail,
     Building,
@@ -35,6 +34,7 @@ import {
     AlertCircle,
     Skip
 } from 'lucide-react';
+import { useLanguage } from '@/hooks/use-language';
 
 interface Tool {
     id: number;
@@ -89,7 +89,6 @@ interface User {
 
 interface AssessmentStartProps {
     assessmentData: AssessmentData;
-    locale: string;
     prefillData?: {
         name: string;
         email: string;
@@ -234,8 +233,8 @@ const translations = {
     }
 };
 
-export default function AssessmentStart({ assessmentData, locale, prefillData, auth }: AssessmentStartProps) {
-    const [language, setLanguage] = useState<'en' | 'ar'>(locale === 'ar' ? 'ar' : 'en');
+export default function AssessmentStart({ assessmentData, prefillData, auth }: AssessmentStartProps) {
+    const { language } = useLanguage();
     const [currentStep, setCurrentStep] = useState<'info' | 'preview' | 'assessment'>('info');
     const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
 
@@ -287,9 +286,6 @@ export default function AssessmentStart({ assessmentData, locale, prefillData, a
         return language === 'ar' ? item[`${field}_ar`] : item[`${field}_en`];
     }
 
-    const toggleLanguage = () => {
-        setLanguage(prev => prev === 'en' ? 'ar' : 'en');
-    };
 
     const handleResponseChange = (criterionId: number, response: 'yes' | 'no' | 'na') => {
         setData('responses', {
@@ -448,15 +444,7 @@ export default function AssessmentStart({ assessmentData, locale, prefillData, a
                                     </div>
                                 </div>
                             </div>
-                            <Button
-                                variant="outline"
-                                size="sm"
-                                onClick={toggleLanguage}
-                                className="backdrop-blur-sm bg-white/50 border-white/30 hover:bg-white/70 transition-all duration-300"
-                            >
-                                <Globe className="w-4 h-4 mr-2" />
-                                <span>{language === 'en' ? 'عربي' : 'English'}</span>
-                            </Button>
+
                         </div>
                     </div>
                 </header>
@@ -684,15 +672,7 @@ export default function AssessmentStart({ assessmentData, locale, prefillData, a
                                     </div>
                                 </div>
                             </div>
-                            <Button
-                                variant="outline"
-                                size="sm"
-                                onClick={toggleLanguage}
-                                className="backdrop-blur-sm bg-white/50 border-white/30 hover:bg-white/70 transition-all duration-300"
-                            >
-                                <Globe className="w-4 h-4 mr-2" />
-                                <span>{language === 'en' ? 'عربي' : 'English'}</span>
-                            </Button>
+
                         </div>
                     </div>
                 </header>
@@ -868,15 +848,7 @@ export default function AssessmentStart({ assessmentData, locale, prefillData, a
                                 </span>
                             </div>
 
-                            <Button
-                                variant="outline"
-                                size="sm"
-                                onClick={toggleLanguage}
-                                className="backdrop-blur-sm bg-white/50 border-white/30 hover:bg-white/70 transition-all duration-300"
-                            >
-                                <Globe className="w-4 h-4 mr-2" />
-                                <span>{language === 'en' ? 'عربي' : 'English'}</span>
-                            </Button>
+
                         </div>
                     </div>
                 </div>

--- a/resources/js/pages/assessment/start2.tsx
+++ b/resources/js/pages/assessment/start2.tsx
@@ -12,7 +12,6 @@ import AppLayout from '@/layouts/app-layout';
 import InputError from '@/components/input-error';
 import { type BreadcrumbItem } from '@/types';
 import {
-    Globe,
     User,
     Mail,
     Building,
@@ -37,6 +36,7 @@ import {
     HelpCircle,
     AlertCircle
 } from 'lucide-react';
+import { useLanguage } from '@/hooks/use-language';
 
 interface Tool {
     id: number;
@@ -91,7 +91,6 @@ interface User {
 
 interface AssessmentStartProps {
     assessmentData: AssessmentData;
-    locale: string;
     prefillData?: {           // Add this
         name: string;
         email: string;
@@ -331,8 +330,8 @@ const translations: Translations = {
     }
 };
 
-export default function AssessmentStart({ assessmentData, locale, prefillData, auth }: AssessmentStartProps) {
-    const [language, setLanguage] = useState<'en' | 'ar'>(locale === 'ar' ? 'ar' : 'en');
+export default function AssessmentStart({ assessmentData, prefillData, auth }: AssessmentStartProps) {
+    const { language } = useLanguage();
     const [currentStep, setCurrentStep] = useState<'info' | 'preview' | 'assessment'>('info');
     const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
 
@@ -366,9 +365,6 @@ export default function AssessmentStart({ assessmentData, locale, prefillData, a
         return language === 'ar' ? item[`${field}_ar`] : item[`${field}_en`];
     }
 
-    const toggleLanguage = () => {
-        setLanguage(prev => prev === 'en' ? 'ar' : 'en');
-    };
 
     const handleResponseChange = (criterionId: number, response: 'yes' | 'no' | 'na') => {
         setData('responses', {
@@ -536,15 +532,7 @@ export default function AssessmentStart({ assessmentData, locale, prefillData, a
                                         </div>
                                     </div>
                                 </div>
-                                <Button
-                                    variant="outline"
-                                    size="sm"
-                                    onClick={toggleLanguage}
-                                    className="backdrop-blur-sm bg-white/50 border-white/30 hover:bg-white/70 transition-all duration-300"
-                                >
-                                    <Globe className="w-4 h-4 mr-2" />
-                                    <span>{language === 'en' ? 'عربي' : 'English'}</span>
-                                </Button>
+                                
                             </div>
                         </div>
                     </header>
@@ -786,15 +774,7 @@ export default function AssessmentStart({ assessmentData, locale, prefillData, a
                                         </div>
                                     </div>
                                 </div>
-                                <Button
-                                    variant="outline"
-                                    size="sm"
-                                    onClick={toggleLanguage}
-                                    className="backdrop-blur-sm bg-white/50 border-white/30 hover:bg-white/70 transition-all duration-300"
-                                >
-                                    <Globe className="w-4 h-4 mr-2" />
-                                    <span>{language === 'en' ? 'عربي' : 'English'}</span>
-                                </Button>
+
                             </div>
                         </div>
                     </header>
@@ -976,15 +956,7 @@ export default function AssessmentStart({ assessmentData, locale, prefillData, a
                                         />
                                     </div>
                                 </div>
-                                <Button
-                                    variant="outline"
-                                    size="sm"
-                                    onClick={toggleLanguage}
-                                    className="backdrop-blur-sm bg-white/50 border-white/30 hover:bg-white/70 transition-all duration-300"
-                                >
-                                    <Globe className="w-4 h-4 mr-2" />
-                                    <span>{language === 'en' ? 'عربي' : 'English'}</span>
-                                </Button>
+
                             </div>
                         </div>
                     </div>

--- a/resources/js/pages/assessments/index.tsx
+++ b/resources/js/pages/assessments/index.tsx
@@ -5,7 +5,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import AppLayout from '@/layouts/app-layout';
 import { type BreadcrumbItem } from '@/types';
-import { Search, Globe, Play, Award } from 'lucide-react';
+import { Search, Play, Award } from 'lucide-react';
 
 interface Assessment {
     id: number;
@@ -32,7 +32,6 @@ interface Assessment {
 
 interface AssessmentsIndexProps {
     assessments: Assessment[];
-    locale: string;
     auth: {
         user: {
             id: number;
@@ -76,9 +75,9 @@ const translations: Translations = {
     }
 };
 
-export default function AssessmentsIndex({ assessments, locale, auth }: AssessmentsIndexProps) {
+export default function AssessmentsIndex({ assessments, auth }: AssessmentsIndexProps) {
     const [searchTerm, setSearchTerm] = useState('');
-    const [language, setLanguage] = useState<'en' | 'ar'>(locale === 'ar' ? 'ar' : 'en');
+    const { language } = useLanguage();
 
     const t = translations[language];
 
@@ -88,10 +87,6 @@ export default function AssessmentsIndex({ assessments, locale, auth }: Assessme
             href: '/assessments',
         },
     ];
-
-    const toggleLanguage = () => {
-        setLanguage((prev) => (prev === 'en' ? 'ar' : 'en'));
-    };
 
     const getText = (item: any, field: string): string =>
         language === 'ar' ? item[`${field}_ar`] : item[`${field}_en`];
@@ -116,10 +111,6 @@ export default function AssessmentsIndex({ assessments, locale, auth }: Assessme
                     <h1 className="text-2xl font-bold flex items-center gap-2">
                         <Award className="w-5 h-5 text-primary" /> {t.title}
                     </h1>
-                    <Button variant="outline" size="sm" onClick={toggleLanguage} className="flex items-center gap-2">
-                        <Globe className="w-4 h-4" />
-                        <span>{language === 'en' ? 'عربي' : 'English'}</span>
-                    </Button>
                 </div>
 
                 <div className="relative mb-6 max-w-md">


### PR DESCRIPTION
## Summary
- add global language context and switch component
- show language switch in sidebar header and translate nav
- update pages to use global language state
- remove per-page language toggles

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6872a155cbe883318cbfa0fdcddf2f23