### PR TITLE
Add direction effect hook

### DIFF
--- a/resources/js/AppWrapper.tsx
+++ b/resources/js/AppWrapper.tsx
@@ -1,0 +1,6 @@
+import { useDirectionEffect } from '@/hooks/use-direction-effect';
+
+export default function AppWrapper({ children }: { children: React.ReactNode }) {
+  useDirectionEffect();
+  return <>{children}</>;
+}

--- a/resources/js/app.tsx
+++ b/resources/js/app.tsx
@@ -7,6 +7,7 @@ import { initializeTheme } from './hooks/use-appearance';
 // 👇 UPDATED IMPORT - Note the .tsx extension
 import { ToastProvider } from './components/ui/use-toast';
 import { LanguageProvider } from './hooks/use-language';
+import AppWrapper from './AppWrapper';
 
 const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
 
@@ -21,7 +22,9 @@ createInertiaApp({
         root.render(
             <ToastProvider>
                 <LanguageProvider>
-                    <App {...props} />
+                    <AppWrapper>
+                        <App {...props} />
+                    </AppWrapper>
                 </LanguageProvider>
             </ToastProvider>
         );

--- a/resources/js/hooks/use-direction-effect.ts
+++ b/resources/js/hooks/use-direction-effect.ts
@@ -1,0 +1,10 @@
+import { useEffect } from 'react';
+import { useLanguage } from '@/hooks/use-language';
+
+export function useDirectionEffect() {
+  const { language } = useLanguage();
+
+  useEffect(() => {
+    document.documentElement.setAttribute('dir', language === 'ar' ? 'rtl' : 'ltr');
+  }, [language]);
+}


### PR DESCRIPTION
## Summary
- add `useDirectionEffect` to toggle the `<html dir>` attribute when the language changes
- wrap application with `AppWrapper` that runs this hook
- update `app.tsx` to include wrapper

## Testing
- `npm run lint` *(fails: several existing lint errors)*
- `npm run types` *(fails: TypeScript errors in unrelated files)*
- `composer test` *(fails: existing PHP test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68736a5d36508331a3e3702963f00d5b