### PR TITLE
Fix blog comments logic and migration checks

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -26,8 +26,11 @@ class PostController extends Controller
             abort(404);
         }
 
-        $comments = $post->comments()->where('approved', true)->latest()->get();
-        $comments = $post->comments()->latest()->get();
+        // Only display approved comments in newest-first order
+        $comments = $post->comments()
+            ->where('approved', true)
+            ->latest()
+            ->get();
 
         return Inertia::render('posts/Show', [
             'post' => $post,
@@ -42,8 +45,8 @@ class PostController extends Controller
             'content' => 'required|string',
         ]);
 
+        // Always create a pending comment awaiting approval
         $post->comments()->create($data + ['approved' => false]);
-        $post->comments()->create($data);
 
         return redirect()->back();
     }

--- a/database/migrations/2025_06_18_054411_create_blog_posts_table.php
+++ b/database/migrations/2025_06_18_054411_create_blog_posts_table.php
@@ -31,7 +31,9 @@ return new class extends Migration
 
             $table->index(['status', 'published_at']);
             $table->index('author_id');
-            $table->fullText(['title', 'excerpt', 'content']);
+            if (Schema::getConnection()->getDriverName() !== 'sqlite') {
+                $table->fullText(['title', 'excerpt', 'content']);
+            }
         });
     }
 

--- a/database/migrations/2025_07_10_072258_add_account_id_to_tool_requests_table.php
+++ b/database/migrations/2025_07_10_072258_add_account_id_to_tool_requests_table.php
@@ -8,16 +8,20 @@ use Illuminate\Support\Facades\Schema;
 return new class extends Migration {
     public function up(): void
     {
-        Schema::table('tool_requests', function (Blueprint $table) {
-            $table->foreignId('account_id')->nullable()->constrained()->nullOnDelete();
-        });
+        if (Schema::hasTable('tool_requests')) {
+            Schema::table('tool_requests', function (Blueprint $table) {
+                $table->foreignId('account_id')->nullable()->constrained()->nullOnDelete();
+            });
+        }
     }
 
     public function down(): void
     {
-        Schema::table('tool_requests', function (Blueprint $table) {
-            $table->dropConstrainedForeignId('account_id');
-        });
+        if (Schema::hasTable('tool_requests')) {
+            Schema::table('tool_requests', function (Blueprint $table) {
+                $table->dropConstrainedForeignId('account_id');
+            });
+        }
     }
 };
 

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -90,8 +90,10 @@
     <link href="https://fonts.bunny.net/css?family=instrument-sans:400,500,600" rel="stylesheet" />
 
     @routes
-    @viteReactRefresh
-    @vite(['resources/js/app.tsx', "resources/js/pages/{$page['component']}.tsx"])
+    @if (!app()->runningUnitTests())
+        @viteReactRefresh
+        @vite(['resources/js/app.tsx', "resources/js/pages/{$page['component']}.tsx"])
+    @endif
     @inertiaHead
     @paddleJS
 </head>


### PR DESCRIPTION
## Summary
- fix comment query and creation in PostController
- skip fulltext index for sqlite
- guard tool_request migration with table check
- avoid Vite assets during testing

## Testing
- `composer install`
- `composer test` *(fails: DashboardTest expected 200 but got 302)*

------
https://chatgpt.com/codex/tasks/task_e_6874da0ab6e08331a17994615906499b