### PR TITLE
Improve assessment pages

### DIFF
--- a/resources/js/components/assessment-header.tsx
+++ b/resources/js/components/assessment-header.tsx
@@ -1,0 +1,37 @@
+import { LanguageSwitch } from '@/components/language-switch';
+import { Users } from 'lucide-react';
+import React from 'react';
+
+interface AssessmentHeaderProps {
+    title: string;
+    userName?: string;
+    rightContent?: React.ReactNode;
+}
+
+export default function AssessmentHeader({ title, userName, rightContent }: AssessmentHeaderProps) {
+    return (
+        <header className="sticky top-0 z-50 border-b border-blue-200/50 bg-white/95 shadow-lg backdrop-blur-md print:shadow-none">
+            <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+                <div className="flex h-16 items-center justify-between">
+                    <div className="flex items-center space-x-4">
+                        <img src="/storage/logo.svg" alt="AFAQ Logo" className="h-10 w-auto" />
+                        <div className="h-6 w-px bg-gray-300" />
+                        <div>
+                            <h1 className="text-lg font-bold text-gray-900">{title}</h1>
+                            {userName && (
+                                <div className="flex items-center space-x-2 text-xs text-gray-600">
+                                    <Users className="h-3 w-3" />
+                                    <span>{userName}</span>
+                                </div>
+                            )}
+                        </div>
+                    </div>
+                    <div className="flex items-center space-x-4 print:hidden">
+                        {rightContent}
+                        <LanguageSwitch />
+                    </div>
+                </div>
+            </div>
+        </header>
+    );
+}

--- a/resources/js/pages/FreeAssessment/Complete.tsx
+++ b/resources/js/pages/FreeAssessment/Complete.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
-import { Head, Link } from '@inertiajs/react';
-import { Button } from '@/components/ui/button';
-import { CheckCircle } from 'lucide-react';
+import AssessmentHeader from '@/components/assessment-header';
+import { useLanguage } from '@/hooks/use-language';
+import { Head, router } from '@inertiajs/react';
+import { Loader2 } from 'lucide-react';
+import { useEffect } from 'react';
 
 interface CompleteProps {
     assessment: {
@@ -15,25 +16,30 @@ interface CompleteProps {
 }
 
 export default function Complete({ assessment, locale }: CompleteProps) {
-    const isArabic = locale === 'ar';
-    const message = isArabic
-        ? `تم الانتهاء من تقييم ${assessment.tool.name_ar}`
-        : `Thank you for completing the ${assessment.tool.name_en} assessment`;
-    const buttonLabel = isArabic ? 'عرض النتيجة' : 'Click here to see results';
+    const { language } = useLanguage();
+    const t = {
+        en: { calculating: 'Calculating Results...' },
+        ar: { calculating: 'جاري حساب النتائج...' },
+    }[language];
+
+    useEffect(() => {
+        const timer = setTimeout(() => {
+            router.visit(route('free-assessment.results', assessment.id));
+        }, 2500);
+        return () => clearTimeout(timer);
+    }, [assessment.id]);
 
     return (
         <>
             <Head title="Assessment Complete" />
+            <AssessmentHeader title={language === 'ar' ? assessment.tool.name_ar : assessment.tool.name_en} />
             <div
-                className={`min-h-screen flex items-center justify-center bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50 ${isArabic ? 'rtl' : 'ltr'}`}
-                dir={isArabic ? 'rtl' : 'ltr'}
+                className={`flex min-h-screen items-center justify-center bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50 ${language === 'ar' ? 'rtl' : 'ltr'}`}
+                dir={language === 'ar' ? 'rtl' : 'ltr'}
             >
-                <div className="text-center space-y-6">
-                    <CheckCircle className="w-16 h-16 text-emerald-600 mx-auto" />
-                    <h1 className="text-2xl font-bold">{message}</h1>
-                    <Button asChild className="bg-gradient-to-r from-emerald-600 to-green-600 hover:from-emerald-700 hover:to-green-700">
-                        <Link href={route('free-assessment.results', assessment.id)}>{buttonLabel}</Link>
-                    </Button>
+                <div className="space-y-6 text-center">
+                    <Loader2 className="mx-auto h-12 w-12 animate-spin text-blue-600" />
+                    <p className="text-xl font-semibold text-gray-700">{t.calculating}</p>
                 </div>
             </div>
         </>

--- a/resources/js/pages/FreeAssessment/Edit.tsx
+++ b/resources/js/pages/FreeAssessment/Edit.tsx
@@ -1,28 +1,28 @@
-import React, { useState, useEffect, useMemo } from 'react';
-import { Head, useForm, router } from '@inertiajs/react';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import AssessmentHeader from '@/components/assessment-header';
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Progress } from '@/components/ui/progress';
 import { Textarea } from '@/components/ui/textarea';
-import { Badge } from '@/components/ui/badge';
+import { useLanguage } from '@/hooks/use-language';
+import { Head, router, useForm } from '@inertiajs/react';
 import {
-    CheckCircle,
-    XCircle,
-    MinusCircle,
-    FileText,
+    ArrowUp,
     Award,
     BarChart3,
-    Upload,
-    File,
-    X,
-    Paperclip,
-    Cloud,
-    ArrowUp,
     CheckCheck,
+    CheckCircle,
     Clock,
-    Users
+    Cloud,
+    File,
+    FileText,
+    MinusCircle,
+    Paperclip,
+    Upload,
+    X,
+    XCircle,
 } from 'lucide-react';
-import { useLanguage } from '@/hooks/use-language';
+import { useEffect, useMemo, useState } from 'react';
 
 interface Criterion {
     id: number;
@@ -101,7 +101,7 @@ export default function Start({ assessmentData, locale, auth, existingNotes }: T
                 });
             }
             return initial;
-        }
+        },
     );
     const [notes, setNotes] = useState<Record<number, string>>(existingNotes || {});
     const [files, setFiles] = useState<Record<number, File | null>>({});
@@ -112,21 +112,21 @@ export default function Start({ assessmentData, locale, auth, existingNotes }: T
     const { data, setData, post, processing } = useForm({
         responses: {},
         notes: {},
-        files: {}
+        files: {},
     });
 
     // Flatten all criteria into a single array with domain and category info
     const allCriteria = useMemo(() => {
         const criteria: (Criterion & { domainName: string; categoryName: string; domainId: number; categoryId: number })[] = [];
-        assessmentData.tool.domains.forEach(domain => {
-            domain.categories.forEach(category => {
-                category.criteria.forEach(criterion => {
+        assessmentData.tool.domains.forEach((domain) => {
+            domain.categories.forEach((category) => {
+                category.criteria.forEach((criterion) => {
                     criteria.push({
                         ...criterion,
                         domainName: language === 'ar' ? domain.name_ar : domain.name_en,
                         categoryName: language === 'ar' ? category.name_ar : category.name_en,
                         domainId: domain.id,
-                        categoryId: category.id
+                        categoryId: category.id,
                     });
                 });
             });
@@ -144,11 +144,9 @@ export default function Start({ assessmentData, locale, auth, existingNotes }: T
 
     // Check if assessment is complete
     const isComplete = useMemo(() => {
-        return allCriteria.every(criterion => {
+        return allCriteria.every((criterion) => {
             const hasResponse = responses[criterion.id];
-            const hasRequiredFile = !criterion.requires_file ||
-                responses[criterion.id] !== 'yes' ||
-                files[criterion.id];
+            const hasRequiredFile = !criterion.requires_file || responses[criterion.id] !== 'yes' || files[criterion.id];
             return hasResponse && hasRequiredFile;
         });
     }, [responses, files, allCriteria]);
@@ -156,7 +154,7 @@ export default function Start({ assessmentData, locale, auth, existingNotes }: T
     // Group criteria by domain and category for better organization
     const groupedCriteria = useMemo(() => {
         const grouped: Record<number, Record<number, typeof allCriteria>> = {};
-        allCriteria.forEach(criterion => {
+        allCriteria.forEach((criterion) => {
             if (!grouped[criterion.domainId]) {
                 grouped[criterion.domainId] = {};
             }
@@ -170,59 +168,59 @@ export default function Start({ assessmentData, locale, auth, existingNotes }: T
 
     const t = {
         en: {
-            assessment: "Assessment",
-            question: "Question",
-            of: "of",
-            yes: "Yes",
-            no: "No",
-            notApplicable: "Not Applicable",
-            notes: "Notes (Optional)",
-            notesPlaceholder: "Add any notes or comments...",
-            complete: "Complete",
-            completed: "Completed",
-            remaining: "Remaining",
-            progress: "Progress",
-            submitAssessment: "Submit Assessment",
-            assessmentComplete: "Assessment Complete!",
-            submitting: "Submitting...",
-            totalQuestions: "Total Questions",
-            attachmentRequired: "Attachment Required",
-            uploadFile: "Upload Supporting Document",
-            changeFile: "Change File",
-            removeFile: "Remove File",
-            dragDropFile: "Drag and drop a file here, or click to select",
-            fileUploaded: "File uploaded successfully",
-            scrollToTop: "Scroll to top",
+            assessment: 'Assessment',
+            question: 'Question',
+            of: 'of',
+            yes: 'Yes',
+            no: 'No',
+            notApplicable: 'Not Applicable',
+            notes: 'Notes (Optional)',
+            notesPlaceholder: 'Add any notes or comments...',
+            complete: 'Complete',
+            completed: 'Completed',
+            remaining: 'Remaining',
+            progress: 'Progress',
+            submitAssessment: 'Submit Assessment',
+            assessmentComplete: 'Assessment Complete!',
+            submitting: 'Submitting...',
+            totalQuestions: 'Total Questions',
+            attachmentRequired: 'Attachment Required',
+            uploadFile: 'Upload Supporting Document',
+            changeFile: 'Change File',
+            removeFile: 'Remove File',
+            dragDropFile: 'Drag and drop a file here, or click to select',
+            fileUploaded: 'File uploaded successfully',
+            scrollToTop: 'Scroll to top',
             startAssessment: "Let's get started with your assessment",
-            welcomeMessage: "Please answer all questions honestly and provide any required documentation."
+            welcomeMessage: 'Please answer all questions honestly and provide any required documentation.',
         },
         ar: {
-            assessment: "التقييم",
-            question: "السؤال",
-            of: "من",
-            yes: "نعم",
-            no: "لا",
-            notApplicable: "غير قابل للتطبيق",
-            notes: "ملاحظات (اختياري)",
-            notesPlaceholder: "أضف أي ملاحظات أو تعليقات...",
-            complete: "مكتمل",
-            completed: "مكتمل",
-            remaining: "متبقي",
-            progress: "التقدم",
-            submitAssessment: "إرسال التقييم",
-            assessmentComplete: "اكتمل التقييم!",
-            submitting: "جاري الإرسال...",
-            totalQuestions: "إجمالي الأسئلة",
-            attachmentRequired: "مرفق مطلوب",
-            uploadFile: "رفع وثيقة داعمة",
-            changeFile: "تغيير الملف",
-            removeFile: "إزالة الملف",
-            dragDropFile: "اسحب وأفلت ملفًا هنا، أو انقر للاختيار",
-            fileUploaded: "تم رفع الملف بنجاح",
-            scrollToTop: "التمرير إلى الأعلى",
-            startAssessment: "لنبدأ بتقييمك",
-            welcomeMessage: "يرجى الإجابة على جميع الأسئلة بصدق وتقديم أي وثائق مطلوبة."
-        }
+            assessment: 'التقييم',
+            question: 'السؤال',
+            of: 'من',
+            yes: 'نعم',
+            no: 'لا',
+            notApplicable: 'غير قابل للتطبيق',
+            notes: 'ملاحظات (اختياري)',
+            notesPlaceholder: 'أضف أي ملاحظات أو تعليقات...',
+            complete: 'مكتمل',
+            completed: 'مكتمل',
+            remaining: 'متبقي',
+            progress: 'التقدم',
+            submitAssessment: 'إرسال التقييم',
+            assessmentComplete: 'اكتمل التقييم!',
+            submitting: 'جاري الإرسال...',
+            totalQuestions: 'إجمالي الأسئلة',
+            attachmentRequired: 'مرفق مطلوب',
+            uploadFile: 'رفع وثيقة داعمة',
+            changeFile: 'تغيير الملف',
+            removeFile: 'إزالة الملف',
+            dragDropFile: 'اسحب وأفلت ملفًا هنا، أو انقر للاختيار',
+            fileUploaded: 'تم رفع الملف بنجاح',
+            scrollToTop: 'التمرير إلى الأعلى',
+            startAssessment: 'لنبدأ بتقييمك',
+            welcomeMessage: 'يرجى الإجابة على جميع الأسئلة بصدق وتقديم أي وثائق مطلوبة.',
+        },
     }[language];
 
     // Handle scroll to show/hide scroll to top button
@@ -235,25 +233,25 @@ export default function Start({ assessmentData, locale, auth, existingNotes }: T
     }, []);
 
     const handleResponseChange = (criterionId: number, response: 'yes' | 'no' | 'na') => {
-        setResponses(prev => ({ ...prev, [criterionId]: response }));
+        setResponses((prev) => ({ ...prev, [criterionId]: response }));
 
         // Clear file if response is not 'yes' for criteria requiring files
-        const criterion = allCriteria.find(c => c.id === criterionId);
+        const criterion = allCriteria.find((c) => c.id === criterionId);
         if (criterion?.requires_file && response !== 'yes') {
-            setFiles(prev => ({ ...prev, [criterionId]: null }));
+            setFiles((prev) => ({ ...prev, [criterionId]: null }));
         }
     };
 
     const handleNotesChange = (criterionId: number, value: string) => {
-        setNotes(prev => ({ ...prev, [criterionId]: value }));
+        setNotes((prev) => ({ ...prev, [criterionId]: value }));
     };
 
     const handleFileUpload = (criterionId: number, file: File) => {
-        setFiles(prev => ({ ...prev, [criterionId]: file }));
+        setFiles((prev) => ({ ...prev, [criterionId]: file }));
     };
 
     const handleFileRemove = (criterionId: number) => {
-        setFiles(prev => ({ ...prev, [criterionId]: null }));
+        setFiles((prev) => ({ ...prev, [criterionId]: null }));
     };
 
     const submitAssessment = () => {
@@ -262,9 +260,8 @@ export default function Start({ assessmentData, locale, auth, existingNotes }: T
         setData({
             responses: responses,
             notes: notes,
-            files: files
+            files: files,
         });
-
 
         // Use the correct route with assessment ID from your existing routes
         router.visit(`${route('free-assessment.edit', assessmentData.id)}`);
@@ -274,80 +271,61 @@ export default function Start({ assessmentData, locale, auth, existingNotes }: T
         window.scrollTo({ top: 0, behavior: 'smooth' });
     };
 
-
     return (
         <>
             <Head title={`${assessmentData.tool.name_en} ${t.assessment}`} />
 
-            <div className={`min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50 ${language === 'ar' ? 'rtl' : 'ltr'}`} dir={language === 'ar' ? 'rtl' : 'ltr'}>
-
-                {/* Fixed Header */}
-                <header className="bg-white/95 backdrop-blur-md shadow-lg border-b border-blue-200/50 sticky top-0 z-50">
-                    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-                        <div className="flex justify-between items-center h-20">
-                            <div className="flex items-center space-x-6">
-                                <img
-                                    src="/storage/logo.svg"
-                                    alt="FAQ Logo"
-                                    className="bg-transparent h-12 w-auto object-contain hover:scale-105 transition-transform duration-200"
-                                />
-                                <div className="h-8 w-px bg-gray-300"></div>
-                                <div>
-                                    <h1 className="text-2xl font-bold text-gray-900">
-                                        {language === 'ar' ? assessmentData.tool.name_ar : assessmentData.tool.name_en}
-                                    </h1>
-                                    <div className="flex items-center space-x-2 text-sm text-gray-600">
-                                        <Users className="w-4 h-4" />
-                                        <span>{auth.user.name}</span>
-                                    </div>
+            <div
+                className={`min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50 ${language === 'ar' ? 'rtl' : 'ltr'}`}
+                dir={language === 'ar' ? 'rtl' : 'ltr'}
+            >
+                <AssessmentHeader
+                    title={language === 'ar' ? assessmentData.tool.name_ar : assessmentData.tool.name_en}
+                    userName={auth.user.name}
+                    rightContent={
+                        <div className="hidden items-center space-x-4 rounded-full bg-blue-50 px-6 py-3 md:flex">
+                            <BarChart3 className="h-5 w-5 text-blue-600" />
+                            <div className="text-right">
+                                <div className="text-lg font-bold text-blue-900">{Math.round(completionPercentage)}%</div>
+                                <div className="text-xs text-blue-700">
+                                    {Object.keys(responses).length}/{totalCriteria}
                                 </div>
                             </div>
-                            <div className="flex items-center space-x-6">
-                                <div className="hidden md:flex items-center space-x-4 bg-blue-50 rounded-full px-6 py-3">
-                                    <BarChart3 className="w-5 h-5 text-blue-600" />
-                                    <div className="text-right">
-                                        <div className="text-lg font-bold text-blue-900">{Math.round(completionPercentage)}%</div>
-                                        <div className="text-xs text-blue-700">{Object.keys(responses).length}/{totalCriteria}</div>
-                                    </div>
-                                    <Progress value={completionPercentage} className="w-24 h-2" />
-                                </div>
-
-                            </div>
+                            <Progress value={completionPercentage} className="h-2 w-24" />
                         </div>
-                    </div>
-                </header>
+                    }
+                />
 
                 {/* Welcome Section */}
-                <div className="py-12 px-4 sm:px-6 lg:px-8">
-                    <div className="max-w-4xl mx-auto">
-                        <Card className="mb-8 border-0 shadow-2xl bg-gradient-to-br from-blue-600 via-purple-600 to-indigo-700 text-white overflow-hidden">
-
+                <div className="px-4 py-12 sm:px-6 lg:px-8">
+                    <div className="mx-auto max-w-4xl">
+                        <Card className="mb-8 overflow-hidden border-0 bg-gradient-to-br from-blue-600 via-purple-600 to-indigo-700 text-white shadow-2xl">
                             <CardContent className="relative p-8 md:p-12">
                                 <div className="text-center">
-                                    <div className="flex items-center justify-center mb-6">
-                                        <div className="w-16 h-16 bg-white/20 rounded-full flex items-center justify-center">
-                                            <FileText className="w-8 h-8" />
+                                    <div className="mb-6 flex items-center justify-center">
+                                        <div className="flex h-16 w-16 items-center justify-center rounded-full bg-white/20">
+                                            <FileText className="h-8 w-8" />
                                         </div>
                                     </div>
-                                    <h2 className="text-3xl md:text-4xl font-bold mb-4">{t.startAssessment}</h2>
-                                    <p className="text-xl text-blue-100 mb-8 max-w-2xl mx-auto">{t.welcomeMessage}</p>
+                                    <h2 className="mb-4 text-3xl font-bold md:text-4xl">{t.startAssessment}</h2>
+                                    <p className="mx-auto mb-8 max-w-2xl text-xl text-blue-100">{t.welcomeMessage}</p>
 
-                                    <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
-                                        <div className="text-center p-4 bg-white/10 rounded-xl backdrop-blur-sm">
+                                    <div className="mb-8 grid grid-cols-1 gap-6 md:grid-cols-3">
+                                        <div className="rounded-xl bg-white/10 p-4 text-center backdrop-blur-sm">
                                             <div className="text-3xl font-bold">{totalCriteria}</div>
                                             <div className="text-blue-100">{t.totalQuestions}</div>
                                         </div>
-                                        <div className="text-center p-4 bg-white/10 rounded-xl backdrop-blur-sm">
+                                        <div className="rounded-xl bg-white/10 p-4 text-center backdrop-blur-sm">
                                             <div className="text-3xl font-bold">{Object.keys(responses).length}</div>
                                             <div className="text-blue-100">{t.completed}</div>
                                         </div>
-                                        <div className="text-center p-4 bg-white/10 rounded-xl backdrop-blur-sm">
+                                        <div className="rounded-xl bg-white/10 p-4 text-center backdrop-blur-sm">
                                             <div className="text-3xl font-bold">{Math.round(completionPercentage)}%</div>
                                             <div className="text-blue-100">{t.progress}</div>
                                         </div>
                                     </div>
 
-                                    <Progress value={completionPercentage} className="bg-white/20 h-3 mb-4" />
+                                    <Progress value={completionPercentage} className="mb-4 h-3 bg-white/20" />
                                 </div>
                             </CardContent>
                         </Card>
@@ -357,49 +335,60 @@ export default function Start({ assessmentData, locale, auth, existingNotes }: T
                             {assessmentData.tool.domains.map((domain) => (
                                 <div key={domain.id} className="space-y-6">
                                     {/* Domain Header */}
-                                    <div className="text-center py-6">
-                                        <h2 className="text-3xl font-bold text-gray-900 mb-2">
+                                    <div className="py-6 text-center">
+                                        <h2 className="mb-2 text-3xl font-bold text-gray-900">
                                             {language === 'ar' ? domain.name_ar : domain.name_en}
                                         </h2>
-                                        <div className="w-24 h-1 bg-gradient-to-r from-blue-600 to-purple-600 mx-auto rounded-full"></div>
+                                        <div className="mx-auto h-1 w-24 rounded-full bg-gradient-to-r from-blue-600 to-purple-600"></div>
                                     </div>
 
                                     {domain.categories.map((category) => (
                                         <div key={category.id} className="space-y-4">
                                             {/* Category Header */}
-                                            <div className="sticky top-24 z-40 bg-white/90 backdrop-blur-md rounded-xl p-4 shadow-lg border border-blue-200/50 mb-6">
-                                                <h3 className="text-xl font-semibold text-gray-800 text-center">
+                                            <div className="sticky top-24 z-40 mb-6 rounded-xl border border-blue-200/50 bg-white/90 p-4 shadow-lg backdrop-blur-md">
+                                                <h3 className="text-center text-xl font-semibold text-gray-800">
                                                     {language === 'ar' ? category.name_ar : category.name_en}
                                                 </h3>
                                             </div>
 
                                             {/* Questions in this category */}
                                             {category.criteria.map((criterion, index) => (
-                                                <Card key={criterion.id} className="border-0 shadow-xl hover:shadow-2xl transition-all duration-300 transform hover:-translate-y-1">
-                                                    <CardHeader className="bg-gradient-to-r from-gray-50 to-blue-50 border-b border-blue-100">
+                                                <Card
+                                                    key={criterion.id}
+                                                    className="transform border-0 shadow-xl transition-all duration-300 hover:-translate-y-1 hover:shadow-2xl"
+                                                >
+                                                    <CardHeader className="border-b border-blue-100 bg-gradient-to-r from-gray-50 to-blue-50">
                                                         <div className="flex items-start justify-between">
-                                                            <div className="flex items-start space-x-4 flex-1">
-                                                                <div className="w-10 h-10 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-bold flex-shrink-0">
-                                                                    {allCriteria.findIndex(c => c.id === criterion.id) + 1}
+                                                            <div className="flex flex-1 items-start space-x-4">
+                                                                <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-blue-600 text-sm font-bold text-white">
+                                                                    {allCriteria.findIndex((c) => c.id === criterion.id) + 1}
                                                                 </div>
                                                                 <div className="flex-1">
-                                                                    <CardTitle className="text-lg leading-relaxed text-gray-900 mb-3">
+                                                                    <CardTitle className="mb-3 text-lg leading-relaxed text-gray-900">
                                                                         {language === 'ar' ? criterion.text_ar : criterion.text_en}
                                                                     </CardTitle>
                                                                     <div className="flex items-center space-x-2">
                                                                         {criterion.requires_file && (
-                                                                            <Badge variant="secondary" className="bg-amber-100 text-amber-800 border-amber-200">
-                                                                                <Paperclip className="w-3 h-3 mr-1" />
+                                                                            <Badge
+                                                                                variant="secondary"
+                                                                                className="border-amber-200 bg-amber-100 text-amber-800"
+                                                                            >
+                                                                                <Paperclip className="mr-1 h-3 w-3" />
                                                                                 {t.attachmentRequired}
                                                                             </Badge>
                                                                         )}
                                                                         {responses[criterion.id] && (
-                                                                            <Badge variant="secondary" className={
-                                                                                responses[criterion.id] === 'yes' ? 'bg-green-100 text-green-800' :
-                                                                                    responses[criterion.id] === 'no' ? 'bg-red-100 text-red-800' :
-                                                                                        'bg-gray-100 text-gray-800'
-                                                                            }>
-                                                                                <CheckCheck className="w-3 h-3 mr-1" />
+                                                                            <Badge
+                                                                                variant="secondary"
+                                                                                className={
+                                                                                    responses[criterion.id] === 'yes'
+                                                                                        ? 'bg-green-100 text-green-800'
+                                                                                        : responses[criterion.id] === 'no'
+                                                                                          ? 'bg-red-100 text-red-800'
+                                                                                          : 'bg-gray-100 text-gray-800'
+                                                                                }
+                                                                            >
+                                                                                <CheckCheck className="mr-1 h-3 w-3" />
                                                                                 Answered
                                                                             </Badge>
                                                                         )}
@@ -407,15 +396,13 @@ export default function Start({ assessmentData, locale, auth, existingNotes }: T
                                                                 </div>
                                                             </div>
                                                             {responses[criterion.id] && (
-                                                                <div className="flex items-center ml-4">
+                                                                <div className="ml-4 flex items-center">
                                                                     {responses[criterion.id] === 'yes' && (
-                                                                        <CheckCircle className="w-8 h-8 text-green-600" />
+                                                                        <CheckCircle className="h-8 w-8 text-green-600" />
                                                                     )}
-                                                                    {responses[criterion.id] === 'no' && (
-                                                                        <XCircle className="w-8 h-8 text-red-600" />
-                                                                    )}
+                                                                    {responses[criterion.id] === 'no' && <XCircle className="h-8 w-8 text-red-600" />}
                                                                     {responses[criterion.id] === 'na' && (
-                                                                        <MinusCircle className="w-8 h-8 text-gray-600" />
+                                                                        <MinusCircle className="h-8 w-8 text-gray-600" />
                                                                     )}
                                                                 </div>
                                                             )}
@@ -425,19 +412,19 @@ export default function Start({ assessmentData, locale, auth, existingNotes }: T
                                                     <CardContent className="p-8">
                                                         <div className="space-y-6">
                                                             {/* Response Buttons */}
-                                                            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                                                            <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
                                                                 <Button
                                                                     variant={responses[criterion.id] === 'yes' ? 'default' : 'outline'}
                                                                     size="lg"
                                                                     onClick={() => handleResponseChange(criterion.id, 'yes')}
-                                                                    className={`h-16 transition-all duration-300 transform hover:scale-105 ${
+                                                                    className={`h-16 transform transition-all duration-300 hover:scale-105 ${
                                                                         responses[criterion.id] === 'yes'
-                                                                            ? 'bg-green-600 hover:bg-green-700 text-white shadow-lg shadow-green-200'
-                                                                            : 'hover:bg-green-50 hover:border-green-300 hover:shadow-lg'
+                                                                            ? 'bg-green-600 text-white shadow-lg shadow-green-200 hover:bg-green-700'
+                                                                            : 'hover:border-green-300 hover:bg-green-50 hover:shadow-lg'
                                                                     }`}
                                                                 >
                                                                     <div className="flex items-center space-x-3">
-                                                                        <CheckCircle className="w-6 h-6" />
+                                                                        <CheckCircle className="h-6 w-6" />
                                                                         <span className="text-lg font-medium">{t.yes}</span>
                                                                     </div>
                                                                 </Button>
@@ -445,14 +432,14 @@ export default function Start({ assessmentData, locale, auth, existingNotes }: T
                                                                     variant={responses[criterion.id] === 'no' ? 'default' : 'outline'}
                                                                     size="lg"
                                                                     onClick={() => handleResponseChange(criterion.id, 'no')}
-                                                                    className={`h-16 transition-all duration-300 transform hover:scale-105 ${
+                                                                    className={`h-16 transform transition-all duration-300 hover:scale-105 ${
                                                                         responses[criterion.id] === 'no'
-                                                                            ? 'bg-red-600 hover:bg-red-700 text-white shadow-lg shadow-red-200'
-                                                                            : 'hover:bg-red-50 hover:border-red-300 hover:shadow-lg'
+                                                                            ? 'bg-red-600 text-white shadow-lg shadow-red-200 hover:bg-red-700'
+                                                                            : 'hover:border-red-300 hover:bg-red-50 hover:shadow-lg'
                                                                     }`}
                                                                 >
                                                                     <div className="flex items-center space-x-3">
-                                                                        <XCircle className="w-6 h-6" />
+                                                                        <XCircle className="h-6 w-6" />
                                                                         <span className="text-lg font-medium">{t.no}</span>
                                                                     </div>
                                                                 </Button>
@@ -460,14 +447,14 @@ export default function Start({ assessmentData, locale, auth, existingNotes }: T
                                                                     variant={responses[criterion.id] === 'na' ? 'default' : 'outline'}
                                                                     size="lg"
                                                                     onClick={() => handleResponseChange(criterion.id, 'na')}
-                                                                    className={`h-16 transition-all duration-300 transform hover:scale-105 ${
+                                                                    className={`h-16 transform transition-all duration-300 hover:scale-105 ${
                                                                         responses[criterion.id] === 'na'
-                                                                            ? 'bg-gray-600 hover:bg-gray-700 text-white shadow-lg shadow-gray-200'
-                                                                            : 'hover:bg-gray-50 hover:border-gray-300 hover:shadow-lg'
+                                                                            ? 'bg-gray-600 text-white shadow-lg shadow-gray-200 hover:bg-gray-700'
+                                                                            : 'hover:border-gray-300 hover:bg-gray-50 hover:shadow-lg'
                                                                     }`}
                                                                 >
                                                                     <div className="flex items-center space-x-3">
-                                                                        <MinusCircle className="w-6 h-6" />
+                                                                        <MinusCircle className="h-6 w-6" />
                                                                         <span className="text-lg font-medium">{t.notApplicable}</span>
                                                                     </div>
                                                                 </Button>
@@ -475,14 +462,16 @@ export default function Start({ assessmentData, locale, auth, existingNotes }: T
 
                                                             {/* File Upload Section - Only show when requires_file is true AND response is 'yes' */}
                                                             {criterion.requires_file && responses[criterion.id] === 'yes' && (
-                                                                <div className="space-y-4 p-6 bg-gradient-to-br from-blue-50 to-indigo-50 border-2 border-blue-200 rounded-xl">
-                                                                    <div className="flex items-center space-x-3 mb-4">
-                                                                        <div className="w-10 h-10 bg-blue-600 rounded-lg flex items-center justify-center">
-                                                                            <Upload className="w-5 h-5 text-white" />
+                                                                <div className="space-y-4 rounded-xl border-2 border-blue-200 bg-gradient-to-br from-blue-50 to-indigo-50 p-6">
+                                                                    <div className="mb-4 flex items-center space-x-3">
+                                                                        <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-blue-600">
+                                                                            <Upload className="h-5 w-5 text-white" />
                                                                         </div>
                                                                         <div>
                                                                             <h4 className="text-lg font-semibold text-blue-900">{t.uploadFile}</h4>
-                                                                            <p className="text-sm text-blue-700">Please provide supporting documentation</p>
+                                                                            <p className="text-sm text-blue-700">
+                                                                                Please provide supporting documentation
+                                                                            </p>
                                                                         </div>
                                                                     </div>
 
@@ -491,45 +480,55 @@ export default function Start({ assessmentData, locale, auth, existingNotes }: T
                                                                             <input
                                                                                 type="file"
                                                                                 id={`file-${criterion.id}`}
-                                                                                className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
+                                                                                className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
                                                                                 onChange={(e) => {
                                                                                     const file = e.target.files?.[0];
                                                                                     if (file) handleFileUpload(criterion.id, file);
                                                                                 }}
                                                                                 accept=".pdf,.doc,.docx,.jpg,.jpeg,.png"
                                                                             />
-                                                                            <div className="border-2 border-dashed border-blue-300 rounded-xl p-8 text-center hover:border-blue-400 hover:bg-blue-25 transition-all duration-300 cursor-pointer group">
-                                                                                <Cloud className="w-16 h-16 text-blue-400 mx-auto mb-4 group-hover:scale-110 transition-transform duration-200" />
-                                                                                <p className="text-blue-800 font-medium mb-2 text-lg">{t.dragDropFile}</p>
+                                                                            <div className="hover:bg-blue-25 group cursor-pointer rounded-xl border-2 border-dashed border-blue-300 p-8 text-center transition-all duration-300 hover:border-blue-400">
+                                                                                <Cloud className="mx-auto mb-4 h-16 w-16 text-blue-400 transition-transform duration-200 group-hover:scale-110" />
+                                                                                <p className="mb-2 text-lg font-medium text-blue-800">
+                                                                                    {t.dragDropFile}
+                                                                                </p>
                                                                                 <p className="text-blue-600">PDF, DOC, DOCX, JPG, PNG (Max 10MB)</p>
                                                                             </div>
                                                                         </div>
                                                                     ) : (
-                                                                        <div className="bg-white border-2 border-blue-200 rounded-xl p-6 shadow-lg">
+                                                                        <div className="rounded-xl border-2 border-blue-200 bg-white p-6 shadow-lg">
                                                                             <div className="flex items-center justify-between">
                                                                                 <div className="flex items-center space-x-4">
-                                                                                    <div className="w-12 h-12 bg-green-100 rounded-xl flex items-center justify-center">
-                                                                                        <File className="w-6 h-6 text-green-600" />
+                                                                                    <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-green-100">
+                                                                                        <File className="h-6 w-6 text-green-600" />
                                                                                     </div>
                                                                                     <div>
-                                                                                        <p className="font-semibold text-gray-900 text-lg">{files[criterion.id]?.name}</p>
+                                                                                        <p className="text-lg font-semibold text-gray-900">
+                                                                                            {files[criterion.id]?.name}
+                                                                                        </p>
                                                                                         <p className="text-sm text-gray-500">
-                                                                                            {((files[criterion.id]?.size || 0) / 1024 / 1024).toFixed(2)} MB
+                                                                                            {((files[criterion.id]?.size || 0) / 1024 / 1024).toFixed(
+                                                                                                2,
+                                                                                            )}{' '}
+                                                                                            MB
                                                                                         </p>
                                                                                     </div>
                                                                                 </div>
                                                                                 <div className="flex items-center space-x-3">
-                                                                                    <Badge variant="secondary" className="bg-green-100 text-green-800 px-3 py-1">
-                                                                                        <CheckCircle className="w-4 h-4 mr-1" />
+                                                                                    <Badge
+                                                                                        variant="secondary"
+                                                                                        className="bg-green-100 px-3 py-1 text-green-800"
+                                                                                    >
+                                                                                        <CheckCircle className="mr-1 h-4 w-4" />
                                                                                         {t.fileUploaded}
                                                                                     </Badge>
                                                                                     <Button
                                                                                         variant="ghost"
                                                                                         size="sm"
                                                                                         onClick={() => handleFileRemove(criterion.id)}
-                                                                                        className="text-red-600 hover:text-red-700 hover:bg-red-50 p-2"
+                                                                                        className="p-2 text-red-600 hover:bg-red-50 hover:text-red-700"
                                                                                     >
-                                                                                        <X className="w-4 h-4" />
+                                                                                        <X className="h-4 w-4" />
                                                                                     </Button>
                                                                                 </div>
                                                                             </div>
@@ -540,9 +539,9 @@ export default function Start({ assessmentData, locale, auth, existingNotes }: T
 
                                                             {/* Notes Section */}
                                                             {responses[criterion.id] && (
-                                                                <div className="space-y-4 p-6 bg-gray-50 border border-gray-200 rounded-xl">
+                                                                <div className="space-y-4 rounded-xl border border-gray-200 bg-gray-50 p-6">
                                                                     <div className="flex items-center space-x-2">
-                                                                        <FileText className="w-5 h-5 text-gray-600" />
+                                                                        <FileText className="h-5 w-5 text-gray-600" />
                                                                         <label className="text-base font-medium text-gray-900">{t.notes}</label>
                                                                     </div>
                                                                     <Textarea
@@ -550,7 +549,7 @@ export default function Start({ assessmentData, locale, auth, existingNotes }: T
                                                                         onChange={(e) => handleNotesChange(criterion.id, e.target.value)}
                                                                         placeholder={t.notesPlaceholder}
                                                                         rows={3}
-                                                                        className="resize-none text-base border-gray-300 focus:border-blue-500 focus:ring-blue-500"
+                                                                        className="resize-none border-gray-300 text-base focus:border-blue-500 focus:ring-blue-500"
                                                                     />
                                                                 </div>
                                                             )}
@@ -566,29 +565,29 @@ export default function Start({ assessmentData, locale, auth, existingNotes }: T
 
                         {/* Submit Assessment */}
                         {isComplete && (
-                            <Card className="mt-12 border-0 shadow-2xl bg-gradient-to-br from-green-600 via-emerald-600 to-teal-600 text-white">
+                            <Card className="mt-12 border-0 bg-gradient-to-br from-green-600 via-emerald-600 to-teal-600 text-white shadow-2xl">
                                 <CardContent className="p-12 text-center">
                                     <div className="space-y-8">
                                         <div className="flex items-center justify-center">
-                                            <div className="w-24 h-24 bg-white/20 rounded-full flex items-center justify-center mb-6 animate-pulse">
-                                                <Award className="w-12 h-12" />
+                                            <div className="mb-6 flex h-24 w-24 animate-pulse items-center justify-center rounded-full bg-white/20">
+                                                <Award className="h-12 w-12" />
                                             </div>
                                         </div>
 
                                         <div>
-                                            <h3 className="text-4xl font-bold mb-4">{t.assessmentComplete}</h3>
-                                            <p className="text-green-100 text-xl mb-8 max-w-2xl mx-auto">
+                                            <h3 className="mb-4 text-4xl font-bold">{t.assessmentComplete}</h3>
+                                            <p className="mx-auto mb-8 max-w-2xl text-xl text-green-100">
                                                 Congratulations! You have successfully completed all {totalCriteria} questions with excellence.
                                             </p>
                                         </div>
 
-                                        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
-                                            <div className="text-center p-6 bg-white/10 rounded-2xl backdrop-blur-sm">
-                                                <div className="text-4xl font-bold mb-2">{totalCriteria}</div>
+                                        <div className="mb-8 grid grid-cols-1 gap-6 md:grid-cols-2">
+                                            <div className="rounded-2xl bg-white/10 p-6 text-center backdrop-blur-sm">
+                                                <div className="mb-2 text-4xl font-bold">{totalCriteria}</div>
                                                 <div className="text-green-100">{t.totalQuestions}</div>
                                             </div>
-                                            <div className="text-center p-6 bg-white/10 rounded-2xl backdrop-blur-sm">
-                                                <div className="text-4xl font-bold mb-2">100%</div>
+                                            <div className="rounded-2xl bg-white/10 p-6 text-center backdrop-blur-sm">
+                                                <div className="mb-2 text-4xl font-bold">100%</div>
                                                 <div className="text-green-100">{t.complete}</div>
                                             </div>
                                         </div>
@@ -597,16 +596,16 @@ export default function Start({ assessmentData, locale, auth, existingNotes }: T
                                             onClick={submitAssessment}
                                             size="lg"
                                             disabled={processing}
-                                            className="bg-white text-green-600 hover:bg-gray-100 px-12 py-6 text-xl font-bold shadow-2xl transform hover:scale-105 transition-all duration-300"
+                                            className="transform bg-white px-12 py-6 text-xl font-bold text-green-600 shadow-2xl transition-all duration-300 hover:scale-105 hover:bg-gray-100"
                                         >
                                             {processing ? (
                                                 <>
-                                                    <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-green-600 mr-4"></div>
+                                                    <div className="mr-4 h-6 w-6 animate-spin rounded-full border-b-2 border-green-600"></div>
                                                     {t.submitting}
                                                 </>
                                             ) : (
                                                 <>
-                                                    <Award className="w-6 h-6 mr-3" />
+                                                    <Award className="mr-3 h-6 w-6" />
                                                     {t.submitAssessment}
                                                 </>
                                             )}
@@ -618,15 +617,15 @@ export default function Start({ assessmentData, locale, auth, existingNotes }: T
 
                         {/* Floating Progress Indicator */}
                         {!isComplete && (
-                            <div className="fixed bottom-6 right-6 z-50">
-                                <Card className="bg-white/95 backdrop-blur-sm shadow-2xl border-0 p-4">
+                            <div className="fixed right-6 bottom-6 z-50">
+                                <Card className="border-0 bg-white/95 p-4 shadow-2xl backdrop-blur-sm">
                                     <div className="flex items-center space-x-3">
-                                        <Clock className="w-5 h-5 text-blue-600" />
+                                        <Clock className="h-5 w-5 text-blue-600" />
                                         <div>
                                             <div className="text-sm font-medium text-gray-900">
                                                 {Object.keys(responses).length} / {totalCriteria}
                                             </div>
-                                            <Progress value={completionPercentage} className="w-24 h-2" />
+                                            <Progress value={completionPercentage} className="h-2 w-24" />
                                         </div>
                                     </div>
                                 </Card>
@@ -637,10 +636,10 @@ export default function Start({ assessmentData, locale, auth, existingNotes }: T
                         {showScrollTop && (
                             <Button
                                 onClick={scrollToTop}
-                                className="fixed bottom-6 left-6 z-50 w-12 h-12 rounded-full bg-blue-600 hover:bg-blue-700 shadow-2xl"
+                                className="fixed bottom-6 left-6 z-50 h-12 w-12 rounded-full bg-blue-600 shadow-2xl hover:bg-blue-700"
                                 size="sm"
                             >
-                                <ArrowUp className="w-5 h-5" />
+                                <ArrowUp className="h-5 w-5" />
                             </Button>
                         )}
                     </div>

--- a/resources/js/pages/FreeAssessment/Index.tsx
+++ b/resources/js/pages/FreeAssessment/Index.tsx
@@ -1,17 +1,11 @@
-import React from 'react';
-import { Head, router } from '@inertiajs/react';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
+import AssessmentHeader from '@/components/assessment-header';
 import { Badge } from '@/components/ui/badge';
-import {
-    Target,
-    FileText,
-    Crown,
-    CheckCircle,
-    Users,
-    Award,
-    Lock
-} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { useLanguage } from '@/hooks/use-language';
+import { Head, router } from '@inertiajs/react';
+import { Award, CheckCircle, Crown, FileText, Lock, Target } from 'lucide-react';
+import React from 'react';
 
 interface Tool {
     id: number;
@@ -45,7 +39,24 @@ interface IndexProps {
 
 export default function Index({ tools, user, locale }: IndexProps) {
     const [isSubmitting, setIsSubmitting] = React.useState<number | null>(null);
-    const isArabic = locale === 'ar';
+    const { language } = useLanguage();
+    const isArabic = language === 'ar';
+
+    const translations = {
+        en: {
+            start: 'Start Free Assessment',
+            starting: 'Starting...',
+            fullAccess: 'Get Full Access',
+            pageTitle: 'Free Assessment',
+        },
+        ar: {
+            start: 'ابدأ التقييم المجاني',
+            starting: 'جاري البدء...',
+            fullAccess: 'الحصول على وصول كامل',
+            pageTitle: 'التقييم المجاني',
+        },
+    } as const;
+    const t = translations[language];
 
     const startAssessment = (toolId: number) => {
         setIsSubmitting(toolId);
@@ -54,7 +65,7 @@ export default function Index({ tools, user, locale }: IndexProps) {
             { tool_id: toolId },
             {
                 onFinish: () => setIsSubmitting(null),
-            }
+            },
         );
     };
 
@@ -69,73 +80,60 @@ export default function Index({ tools, user, locale }: IndexProps) {
 
     return (
         <>
-            <Head title="Free Assessment" />
+            <Head title={t.pageTitle} />
 
-            <div className={`min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50 ${isArabic ? 'rtl' : 'ltr'}`} dir={isArabic ? 'rtl' : 'ltr'}>
-                {/* Header */}
-                <header className="bg-white/95 backdrop-blur-md shadow-lg border-b border-blue-200/50 sticky top-0 z-50">
-                    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-                        <div className="flex justify-between items-center h-20">
-                            <div className="flex items-center space-x-6">
-                                <img
-                                    src="/storage/logo.svg"
-                                    alt="FAQ Logo"
-                                    className="bg-transparent h-12 w-auto object-contain hover:scale-105 transition-transform duration-200"
-                                />
-                                <div className="h-8 w-px bg-gray-300"></div>
-                                <div>
-                                    <h1 className="text-2xl font-bold text-gray-900">Free Assessment</h1>
-                                    <div className="flex items-center space-x-2 text-sm text-gray-600">
-                                        <Users className="w-4 h-4" />
-                                        <span>{user.name}</span>
-                                    </div>
-                                </div>
-                            </div>
-                            <Badge className="bg-blue-100 text-blue-800 px-4 py-2">
-                                <Crown className="w-4 h-4 mr-2" />
-                                Free Plan
-                            </Badge>
-                        </div>
-                    </div>
-                </header>
+            <div
+                className={`min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50 ${isArabic ? 'rtl' : 'ltr'}`}
+                dir={isArabic ? 'rtl' : 'ltr'}
+            >
+                <AssessmentHeader
+                    title={t.pageTitle}
+                    userName={user.name}
+                    rightContent={
+                        <Badge className="bg-blue-100 px-4 py-2 text-blue-800">
+                            <Crown className="mr-2 h-4 w-4" />
+                            Free Plan
+                        </Badge>
+                    }
+                />
 
                 {/* Main Content */}
-                <div className="py-12 px-4 sm:px-6 lg:px-8">
-                    <div className="max-w-4xl mx-auto">
+                <div className="px-4 py-12 sm:px-6 lg:px-8">
+                    <div className="mx-auto max-w-4xl">
                         {/* Welcome Card */}
-                        <Card className="mb-8 border-0 shadow-2xl bg-gradient-to-br from-blue-600 via-purple-600 to-indigo-700 text-white overflow-hidden">
+                        <Card className="mb-8 overflow-hidden border-0 bg-gradient-to-br from-blue-600 via-purple-600 to-indigo-700 text-white shadow-2xl">
                             <CardContent className="relative p-8 md:p-12">
                                 <div className="text-center">
-                                    <div className="flex items-center justify-center mb-6">
-                                        <div className="w-16 h-16 bg-white/20 rounded-full flex items-center justify-center">
-                                            <FileText className="w-8 h-8" />
+                                    <div className="mb-6 flex items-center justify-center">
+                                        <div className="flex h-16 w-16 items-center justify-center rounded-full bg-white/20">
+                                            <FileText className="h-8 w-8" />
                                         </div>
                                     </div>
-                                    <h2 className="text-3xl md:text-4xl font-bold mb-4">Welcome to Your Free Assessment</h2>
-                                    <p className="text-xl text-blue-100 mb-8 max-w-2xl mx-auto">
-                                        Get started with a comprehensive evaluation of your organization's capabilities.
-                                        This assessment will help you identify strengths and areas for improvement.
+                                    <h2 className="mb-4 text-3xl font-bold md:text-4xl">Welcome to Your Free Assessment</h2>
+                                    <p className="mx-auto mb-8 max-w-2xl text-xl text-blue-100">
+                                        Get started with a comprehensive evaluation of your organization's capabilities. This assessment will help you
+                                        identify strengths and areas for improvement.
                                     </p>
                                 </div>
                             </CardContent>
                         </Card>
-                        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8 mb-12">
+                        <div className="mb-12 grid gap-8 md:grid-cols-2 lg:grid-cols-3">
                             {tools.map((tool) => (
-                                <Card key={tool.id} className="border-0 shadow-lg hover:shadow-xl transition-shadow">
+                                <Card key={tool.id} className="border-0 shadow-lg transition-shadow hover:shadow-xl">
                                     <CardHeader>
                                         <CardTitle className="flex items-center gap-3">
-                                            <Target className="w-6 h-6 text-blue-600" />
+                                            <Target className="h-6 w-6 text-blue-600" />
                                             {getName(tool)}
                                         </CardTitle>
                                     </CardHeader>
                                     <CardContent>
-                                        {getDescription(tool) && <p className="text-gray-600 mb-4">{getDescription(tool)}</p>}
+                                        {getDescription(tool) && <p className="mb-4 text-gray-600">{getDescription(tool)}</p>}
                                         <Button
                                             onClick={() => startAssessment(tool.id)}
                                             disabled={isSubmitting === tool.id}
                                             className="w-full bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700"
                                         >
-                                            {isSubmitting === tool.id ? 'Starting...' : 'Start'}
+                                            {isSubmitting === tool.id ? t.starting : t.start}
                                         </Button>
                                     </CardContent>
                                 </Card>
@@ -150,39 +148,49 @@ export default function Index({ tools, user, locale }: IndexProps) {
                             <CardContent>
                                 <div className="space-y-6">
                                     <div className="flex items-start space-x-4">
-                                        <div className="w-8 h-8 bg-blue-100 rounded-full flex items-center justify-center flex-shrink-0 mt-1">
-                                            <span className="text-blue-600 text-sm font-bold">1</span>
+                                        <div className="mt-1 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-blue-100">
+                                            <span className="text-sm font-bold text-blue-600">1</span>
                                         </div>
                                         <div>
-                                            <h4 className="font-semibold text-gray-900 mb-2">Assessment Questions</h4>
-                                            <p className="text-gray-600">Answer questions about your organization's current practices and capabilities across multiple domains.</p>
+                                            <h4 className="mb-2 font-semibold text-gray-900">Assessment Questions</h4>
+                                            <p className="text-gray-600">
+                                                Answer questions about your organization's current practices and capabilities across multiple domains.
+                                            </p>
                                         </div>
                                     </div>
                                     <div className="flex items-start space-x-4">
-                                        <div className="w-8 h-8 bg-blue-100 rounded-full flex items-center justify-center flex-shrink-0 mt-1">
-                                            <span className="text-blue-600 text-sm font-bold">2</span>
+                                        <div className="mt-1 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-blue-100">
+                                            <span className="text-sm font-bold text-blue-600">2</span>
                                         </div>
                                         <div>
-                                            <h4 className="font-semibold text-gray-900 mb-2">Provide Documentation</h4>
-                                            <p className="text-gray-600">Upload supporting documents when required to validate your responses and ensure accuracy.</p>
+                                            <h4 className="mb-2 font-semibold text-gray-900">Provide Documentation</h4>
+                                            <p className="text-gray-600">
+                                                Upload supporting documents when required to validate your responses and ensure accuracy.
+                                            </p>
                                         </div>
                                     </div>
                                     <div className="flex items-start space-x-4">
-                                        <div className="w-8 h-8 bg-blue-100 rounded-full flex items-center justify-center flex-shrink-0 mt-1">
-                                            <span className="text-blue-600 text-sm font-bold">3</span>
+                                        <div className="mt-1 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-blue-100">
+                                            <span className="text-sm font-bold text-blue-600">3</span>
                                         </div>
                                         <div>
-                                            <h4 className="font-semibold text-gray-900 mb-2">Get Your Results</h4>
-                                            <p className="text-gray-600">Receive a comprehensive report with your assessment scores, domain breakdown, and basic recommendations.</p>
+                                            <h4 className="mb-2 font-semibold text-gray-900">Get Your Results</h4>
+                                            <p className="text-gray-600">
+                                                Receive a comprehensive report with your assessment scores, domain breakdown, and basic
+                                                recommendations.
+                                            </p>
                                         </div>
                                     </div>
                                     <div className="flex items-start space-x-4">
-                                        <div className="w-8 h-8 bg-amber-100 rounded-full flex items-center justify-center flex-shrink-0 mt-1">
-                                            <Lock className="w-4 h-4 text-amber-600" />
+                                        <div className="mt-1 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-amber-100">
+                                            <Lock className="h-4 w-4 text-amber-600" />
                                         </div>
                                         <div>
-                                            <h4 className="font-semibold text-gray-900 mb-2">Premium Features Available</h4>
-                                            <p className="text-gray-600">Upgrade to access detailed analytics, benchmarking, advanced recommendations, and comprehensive reports.</p>
+                                            <h4 className="mb-2 font-semibold text-gray-900">Premium Features Available</h4>
+                                            <p className="text-gray-600">
+                                                Upgrade to access detailed analytics, benchmarking, advanced recommendations, and comprehensive
+                                                reports.
+                                            </p>
                                         </div>
                                     </div>
                                 </div>
@@ -193,65 +201,62 @@ export default function Index({ tools, user, locale }: IndexProps) {
                         <Card className="border-0 shadow-lg">
                             <CardHeader>
                                 <CardTitle className="flex items-center gap-2">
-                                    <Award className="w-6 h-6 text-blue-600" />
+                                    <Award className="h-6 w-6 text-blue-600" />
                                     Free vs Premium Features
                                 </CardTitle>
                             </CardHeader>
                             <CardContent>
-                                <div className="grid md:grid-cols-2 gap-6">
+                                <div className="grid gap-6 md:grid-cols-2">
                                     <div className="space-y-4">
-                                        <h4 className="font-semibold text-green-600 flex items-center">
-                                            <CheckCircle className="w-5 h-5 mr-2" />
+                                        <h4 className="flex items-center font-semibold text-green-600">
+                                            <CheckCircle className="mr-2 h-5 w-5" />
                                             Included in Free Plan
                                         </h4>
                                         <ul className="space-y-2">
                                             <li className="flex items-center text-gray-600">
-                                                <CheckCircle className="w-4 h-4 text-green-500 mr-2" />
+                                                <CheckCircle className="mr-2 h-4 w-4 text-green-500" />
                                                 Complete assessment access
                                             </li>
                                             <li className="flex items-center text-gray-600">
-                                                <CheckCircle className="w-4 h-4 text-green-500 mr-2" />
+                                                <CheckCircle className="mr-2 h-4 w-4 text-green-500" />
                                                 Basic scoring and results
                                             </li>
                                             <li className="flex items-center text-gray-600">
-                                                <CheckCircle className="w-4 h-4 text-green-500 mr-2" />
+                                                <CheckCircle className="mr-2 h-4 w-4 text-green-500" />
                                                 Domain-level breakdown
                                             </li>
                                             <li className="flex items-center text-gray-600">
-                                                <CheckCircle className="w-4 h-4 text-green-500 mr-2" />
+                                                <CheckCircle className="mr-2 h-4 w-4 text-green-500" />
                                                 Assessment editing capability
                                             </li>
                                         </ul>
                                     </div>
                                     <div className="space-y-4">
-                                        <h4 className="font-semibold text-purple-600 flex items-center">
-                                            <Crown className="w-5 h-5 mr-2" />
+                                        <h4 className="flex items-center font-semibold text-purple-600">
+                                            <Crown className="mr-2 h-5 w-5" />
                                             Premium Features
                                         </h4>
                                         <ul className="space-y-2">
                                             <li className="flex items-center text-gray-600">
-                                                <Crown className="w-4 h-4 text-purple-500 mr-2" />
+                                                <Crown className="mr-2 h-4 w-4 text-purple-500" />
                                                 Advanced analytics & insights
                                             </li>
                                             <li className="flex items-center text-gray-600">
-                                                <Crown className="w-4 h-4 text-purple-500 mr-2" />
+                                                <Crown className="mr-2 h-4 w-4 text-purple-500" />
                                                 Industry benchmarking
                                             </li>
                                             <li className="flex items-center text-gray-600">
-                                                <Crown className="w-4 h-4 text-purple-500 mr-2" />
+                                                <Crown className="mr-2 h-4 w-4 text-purple-500" />
                                                 Detailed improvement roadmap
                                             </li>
                                             <li className="flex items-center text-gray-600">
-                                                <Crown className="w-4 h-4 text-purple-500 mr-2" />
+                                                <Crown className="mr-2 h-4 w-4 text-purple-500" />
                                                 Comprehensive PDF reports
                                             </li>
                                         </ul>
-                                        <Button
-                                            variant="outline"
-                                            className="w-full border-purple-600 text-purple-600 hover:bg-purple-50"
-                                        >
-                                            <Crown className="w-4 h-4 mr-2" />
-                                            Learn About Premium
+                                        <Button variant="outline" className="w-full border-purple-600 text-purple-600 hover:bg-purple-50">
+                                            <Crown className="mr-2 h-4 w-4" />
+                                            {t.fullAccess}
                                         </Button>
                                     </div>
                                 </div>

--- a/resources/js/pages/FreeAssessment/Results.tsx
+++ b/resources/js/pages/FreeAssessment/Results.tsx
@@ -1,25 +1,11 @@
-import React, { useState } from 'react';
-import { Head, Link } from '@inertiajs/react';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
+import AssessmentHeader from '@/components/assessment-header';
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Progress } from '@/components/ui/progress';
-import {
-    Award,
-    Download,
-    Edit,
-    Users,
-    CheckCircle,
-    TrendingUp,
-    BarChart3,
-    Crown,
-    FileText,
-    Star,
-    Target,
-    Calendar,
-    Share2
-} from 'lucide-react';
 import { useLanguage } from '@/hooks/use-language';
+import { Head, Link } from '@inertiajs/react';
+import { Award, BarChart3, Crown, Download, Edit, Share2, Star, Target } from 'lucide-react';
 
 interface Assessment {
     id: number;
@@ -68,6 +54,20 @@ export default function Results({ assessment, statistics, domainScores, user, ca
     const { language } = useLanguage();
     const isArabic = language === 'ar';
 
+    const translations = {
+        en: {
+            results: 'Assessment Results',
+            completed: 'Assessment Completed Successfully',
+            download: 'Download',
+        },
+        ar: {
+            results: 'نتائج التقييم',
+            completed: 'تم إكمال التقييم بنجاح',
+            download: 'تحميل',
+        },
+    } as const;
+    const t = translations[language];
+
     const getScoreGrade = (score: number) => {
         if (score >= 90) return { grade: 'A+', color: 'text-green-600', bg: 'bg-green-100' };
         if (score >= 80) return { grade: 'A', color: 'text-green-600', bg: 'bg-green-100' };
@@ -91,7 +91,7 @@ export default function Results({ assessment, statistics, domainScores, user, ca
             month: 'long',
             day: 'numeric',
             hour: '2-digit',
-            minute: '2-digit'
+            minute: '2-digit',
         });
     };
 
@@ -99,91 +99,97 @@ export default function Results({ assessment, statistics, domainScores, user, ca
         <>
             <Head title={`Assessment Results - ${assessment.name}`} />
 
-            <div className={`min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50 ${isArabic ? 'rtl' : 'ltr'} print:bg-white`} dir={isArabic ? 'rtl' : 'ltr'}>
-
-                {/* OPTIMIZED: Compact Header */}
-                <header className="bg-white/95 backdrop-blur-md shadow-lg border-b border-blue-200/50 print:shadow-none">
-                    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-                        <div className="flex justify-between items-center h-16"> {/* Reduced height from h-20 to h-16 */}
-                            <div className="flex items-center space-x-4"> {/* Reduced spacing */}
-                                <div className="flex items-center space-x-3">
-                                    <Award className="w-6 h-6 text-blue-600" /> {/* Reduced icon size */}
-                                    <div>
-                                        <h1 className="text-lg font-bold text-gray-900">Assessment Results</h1> {/* Reduced text size */}
-                                        <div className="flex items-center space-x-2 text-xs text-gray-600"> {/* Reduced text size */}
-                                            <Users className="w-3 h-3" />
-                                            <span>{user.name}</span>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div className="flex items-center space-x-3 print:hidden"> {/* Reduced spacing */}
-                                <Badge className="bg-blue-100 text-blue-800 px-3 py-1 text-xs"> {/* Reduced padding and text size */}
-                                    <Award className="w-3 h-3 mr-1" />
-                                    Free Plan
-                                </Badge>
-                            </div>
-                        </div>
-                    </div>
-                </header>
+            <div
+                className={`min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50 ${isArabic ? 'rtl' : 'ltr'} print:bg-white`}
+                dir={isArabic ? 'rtl' : 'ltr'}
+            >
+                <AssessmentHeader
+                    title={t.results}
+                    userName={user.name}
+                    rightContent={
+                        <Badge className="bg-blue-100 px-3 py-1 text-xs text-blue-800 print:hidden">
+                            <Award className="mr-1 h-3 w-3" />
+                            Free Plan
+                        </Badge>
+                    }
+                />
 
                 {/* OPTIMIZED: Single Container with Grid Layout */}
-                <div className="py-6 px-4 sm:px-6 lg:px-8"> {/* Reduced padding */}
-                    <div className="max-w-7xl mx-auto">
-
+                <div className="px-4 py-6 sm:px-6 lg:px-8">
+                    {' '}
+                    {/* Reduced padding */}
+                    <div className="mx-auto max-w-7xl">
                         {/* OPTIMIZED: Compact Congratulations Banner */}
-                        <Card className="mb-6 border-0 shadow-xl bg-gradient-to-r from-green-600 to-emerald-600 text-white print:shadow-none"> {/* Reduced margin */}
-                            <CardContent className="p-6"> {/* Reduced padding */}
+                        <Card className="mb-6 border-0 bg-gradient-to-r from-green-600 to-emerald-600 text-white shadow-xl print:shadow-none">
+                            {' '}
+                            {/* Reduced margin */}
+                            <CardContent className="p-6">
+                                {' '}
+                                {/* Reduced padding */}
                                 <div className="flex items-center justify-between">
                                     <div className="flex items-center space-x-4">
-                                        <div className="w-12 h-12 bg-white/20 rounded-full flex items-center justify-center"> {/* Reduced size */}
-                                            <Award className="w-6 h-6" />
+                                        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-white/20">
+                                            {' '}
+                                            {/* Reduced size */}
+                                            <Award className="h-6 w-6" />
                                         </div>
                                         <div>
-                                            <h2 className="text-2xl font-bold mb-1">🎉 Congratulations!</h2> {/* Reduced text size */}
-                                            <p className="text-green-100 text-sm">Assessment completed successfully</p> {/* Reduced text size */}
+                                            <h2 className="mb-1 text-2xl font-bold">{t.completed}</h2>
                                         </div>
                                     </div>
                                     <div className="text-right">
                                         <div className="text-3xl font-bold">{Math.round(assessment.overall_score)}%</div> {/* Reduced text size */}
-                                        <div className="text-green-100 text-sm">Overall Score</div>
+                                        <div className="text-sm text-green-100">Overall Score</div>
                                     </div>
                                 </div>
                             </CardContent>
                         </Card>
 
                         {/* OPTIMIZED: Two-Column Layout */}
-                        <div className="grid lg:grid-cols-3 gap-6"> {/* Reduced gap */}
-
+                        <div className="grid gap-6 lg:grid-cols-3 print:grid-cols-1">
+                            {' '}
+                            {/* Reduced gap */}
                             {/* OPTIMIZED: Main Results Section - Compact */}
-                            <div className="lg:col-span-2 space-y-6"> {/* Reduced spacing */}
-
+                            <div className="space-y-6 lg:col-span-2">
+                                {' '}
+                                {/* Reduced spacing */}
                                 {/* Score Overview */}
                                 <Card className="border-0 shadow-xl print:shadow-none">
-                                    <CardHeader className="pb-3"> {/* Reduced padding */}
-                                        <CardTitle className="flex items-center gap-2 text-lg"> {/* Reduced text size */}
-                                            <BarChart3 className="w-5 h-5 text-blue-600" />
+                                    <CardHeader className="pb-3">
+                                        {' '}
+                                        {/* Reduced padding */}
+                                        <CardTitle className="flex items-center gap-2 text-lg">
+                                            {' '}
+                                            {/* Reduced text size */}
+                                            <BarChart3 className="h-5 w-5 text-blue-600" />
                                             Assessment Summary
                                         </CardTitle>
                                     </CardHeader>
                                     <CardContent>
-                                        <div className="grid md:grid-cols-3 gap-4"> {/* Reduced gap */}
-
+                                        <div className="grid gap-4 md:grid-cols-3">
+                                            {' '}
+                                            {/* Reduced gap */}
                                             {/* Score Circle - Compact */}
                                             <div className="text-center">
-                                                <div className={`w-20 h-20 rounded-full bg-gradient-to-r ${getScoreColorClass(assessment.overall_score)} flex items-center justify-center text-white mx-auto mb-3`}> {/* Reduced size */}
+                                                <div
+                                                    className={`h-20 w-20 rounded-full bg-gradient-to-r ${getScoreColorClass(assessment.overall_score)} mx-auto mb-3 flex items-center justify-center text-white`}
+                                                >
+                                                    {' '}
+                                                    {/* Reduced size */}
                                                     <div>
-                                                        <div className="text-xl font-bold">{Math.round(assessment.overall_score)}%</div> {/* Reduced text size */}
+                                                        <div className="text-xl font-bold">{Math.round(assessment.overall_score)}%</div>{' '}
+                                                        {/* Reduced text size */}
                                                         <div className="text-xs opacity-90">Score</div>
                                                     </div>
                                                 </div>
-                                                <Badge className={`${overallGrade.bg} ${overallGrade.color} font-bold px-3 py-1`}>
+                                                <Badge className={`${overallGrade.bg} ${overallGrade.color} px-3 py-1 font-bold`}>
                                                     Grade {overallGrade.grade}
                                                 </Badge>
                                             </div>
-
                                             {/* Statistics - Compact */}
-                                            <div className="space-y-2"> {/* Reduced spacing */}
+                                            <div className="space-y-2">
+                                                {' '}
+                                                {/* Reduced spacing */}
                                                 <div className="flex justify-between text-sm">
                                                     <span className="text-gray-600">Total Questions:</span>
                                                     <span className="font-semibold">{statistics.total_questions}</span>
@@ -201,9 +207,10 @@ export default function Results({ assessment, statistics, domainScores, user, ca
                                                     <span className="font-semibold text-gray-600">{statistics.na_answers}</span>
                                                 </div>
                                             </div>
-
                                             {/* Assessment Info - Compact */}
-                                            <div className="space-y-2"> {/* Reduced spacing */}
+                                            <div className="space-y-2">
+                                                {' '}
+                                                {/* Reduced spacing */}
                                                 <div className="text-sm">
                                                     <span className="text-gray-600">Tool:</span>
                                                     <div className="font-semibold text-blue-600">{assessment.tool.name_en}</div>
@@ -222,30 +229,35 @@ export default function Results({ assessment, statistics, domainScores, user, ca
                                         </div>
                                     </CardContent>
                                 </Card>
-
                                 {/* OPTIMIZED: Compact Domain Scores */}
                                 <Card className="border-0 shadow-xl print:shadow-none">
-                                    <CardHeader className="pb-3"> {/* Reduced padding */}
-                                        <CardTitle className="flex items-center gap-2 text-lg"> {/* Reduced text size */}
-                                            <Target className="w-5 h-5 text-blue-600" />
+                                    <CardHeader className="pb-3">
+                                        {' '}
+                                        {/* Reduced padding */}
+                                        <CardTitle className="flex items-center gap-2 text-lg">
+                                            {' '}
+                                            {/* Reduced text size */}
+                                            <Target className="h-5 w-5 text-blue-600" />
                                             Domain Performance
                                         </CardTitle>
                                     </CardHeader>
                                     <CardContent>
-                                        <div className="space-y-3"> {/* Reduced spacing */}
+                                        <div className="space-y-3">
+                                            {' '}
+                                            {/* Reduced spacing */}
                                             {domainScores.map((domain, index) => (
-                                                <div key={index} className="flex items-center justify-between py-2"> {/* Reduced padding */}
+                                                <div key={index} className="flex items-center justify-between py-2">
+                                                    {' '}
+                                                    {/* Reduced padding */}
                                                     <div className="flex-1">
-                                                        <div className="flex items-center justify-between mb-1">
-                                                            <span className="text-sm font-medium text-gray-900">{domain.domain_name}</span> {/* Reduced text size */}
+                                                        <div className="mb-1 flex items-center justify-between">
+                                                            <span className="text-sm font-medium text-gray-900">{domain.domain_name}</span>{' '}
+                                                            {/* Reduced text size */}
                                                             <span className={`text-sm font-bold ${getScoreGrade(domain.score).color}`}>
                                                                 {Math.round(domain.score)}%
                                                             </span>
                                                         </div>
-                                                        <Progress
-                                                            value={domain.score}
-                                                            className="h-2" /* Reduced height */
-                                                        />
+                                                        <Progress value={domain.score} className="h-2" /* Reduced height */ />
                                                     </div>
                                                 </div>
                                             ))}
@@ -253,86 +265,100 @@ export default function Results({ assessment, statistics, domainScores, user, ca
                                     </CardContent>
                                 </Card>
                             </div>
-
                             {/* OPTIMIZED: Compact Actions Sidebar */}
-                            <div className="space-y-6"> {/* Reduced spacing */}
-
+                            <div className="space-y-6">
+                                {' '}
+                                {/* Reduced spacing */}
                                 {/* Actions Card */}
                                 <Card className="border-0 shadow-xl print:hidden">
-                                    <CardHeader className="pb-3"> {/* Reduced padding */}
+                                    <CardHeader className="pb-3">
+                                        {' '}
+                                        {/* Reduced padding */}
                                         <CardTitle className="text-lg">Actions</CardTitle> {/* Reduced text size */}
                                     </CardHeader>
-                                    <CardContent className="space-y-3"> {/* Reduced spacing */}
-
+                                    <CardContent className="space-y-3">
+                                        {' '}
+                                        {/* Reduced spacing */}
                                         {canEdit && (
                                             <Link href={route('free-assessment.edit', assessment.id)}>
-                                                <Button className="w-full bg-blue-600 hover:bg-blue-700 text-sm py-2"> {/* Reduced padding and text size */}
-                                                    <Edit className="w-4 h-4 mr-2" />
+                                                <Button className="w-full bg-blue-600 py-2 text-sm hover:bg-blue-700">
+                                                    {' '}
+                                                    {/* Reduced padding and text size */}
+                                                    <Edit className="mr-2 h-4 w-4" />
                                                     Edit Assessment
                                                 </Button>
                                             </Link>
                                         )}
-
-                                        <Button
-                                            onClick={() => window.print()}
-                                            variant="outline"
-                                            className="w-full text-sm py-2" /* Reduced padding and text size */
-                                        >
-                                            <Download className="w-4 h-4 mr-2" />
-                                            Download Report
+                                        <Button onClick={() => window.print()} variant="outline" className="w-full py-2 text-sm print:hidden">
+                                            <Download className="mr-2 h-4 w-4" />
+                                            {t.download}
                                         </Button>
-
-                                        <Button
-                                            variant="outline"
-                                            className="w-full text-sm py-2" /* Reduced padding and text size */
-                                        >
-                                            <Share2 className="w-4 h-4 mr-2" />
+                                        <Button variant="outline" className="w-full py-2 text-sm" /* Reduced padding and text size */>
+                                            <Share2 className="mr-2 h-4 w-4" />
                                             Share Results
                                         </Button>
                                     </CardContent>
                                 </Card>
-
                                 {/* Upgrade Prompt */}
                                 {!user.is_premium && (
-                                    <Card className="border-0 shadow-xl bg-gradient-to-r from-purple-600 to-pink-600 text-white print:hidden">
-                                        <CardContent className="p-4"> {/* Reduced padding */}
+                                    <Card className="border-0 bg-gradient-to-r from-purple-600 to-pink-600 text-white shadow-xl print:hidden">
+                                        <CardContent className="p-4">
+                                            {' '}
+                                            {/* Reduced padding */}
                                             <div className="text-center">
-                                                <Crown className="w-8 h-8 mx-auto mb-3" /> {/* Reduced size */}
-                                                <h3 className="text-lg font-bold mb-2">Upgrade to Premium</h3> {/* Reduced text size */}
-                                                <p className="text-purple-100 text-sm mb-4"> {/* Reduced text size */}
+                                                <Crown className="mx-auto mb-3 h-8 w-8" /> {/* Reduced size */}
+                                                <h3 className="mb-2 text-lg font-bold">Upgrade to Premium</h3> {/* Reduced text size */}
+                                                <p className="mb-4 text-sm text-purple-100">
+                                                    {' '}
+                                                    {/* Reduced text size */}
                                                     Get detailed analytics, custom reports, and unlimited assessments.
                                                 </p>
                                                 <Button
-                                                    className="w-full bg-white text-purple-600 hover:bg-gray-50 text-sm py-2" /* Reduced padding and text size */
+                                                    className="w-full bg-white py-2 text-sm text-purple-600 hover:bg-gray-50" /* Reduced padding and text size */
                                                 >
-                                                    <Star className="w-4 h-4 mr-2" />
+                                                    <Star className="mr-2 h-4 w-4" />
                                                     Upgrade Now
                                                 </Button>
                                             </div>
                                         </CardContent>
                                     </Card>
                                 )}
-
                                 {/* Quick Stats */}
                                 <Card className="border-0 shadow-xl print:shadow-none">
-                                    <CardHeader className="pb-3"> {/* Reduced padding */}
+                                    <CardHeader className="pb-3">
+                                        {' '}
+                                        {/* Reduced padding */}
                                         <CardTitle className="text-lg">Quick Stats</CardTitle> {/* Reduced text size */}
                                     </CardHeader>
-                                    <CardContent className="space-y-3"> {/* Reduced spacing */}
-                                        <div className="flex items-center justify-between py-1"> {/* Reduced padding */}
+                                    <CardContent className="space-y-3">
+                                        {' '}
+                                        {/* Reduced spacing */}
+                                        <div className="flex items-center justify-between py-1">
+                                            {' '}
+                                            {/* Reduced padding */}
                                             <span className="text-sm text-gray-600">Completion Rate</span>
-                                            <Badge className="bg-green-100 text-green-800 text-xs">100%</Badge> {/* Reduced text size */}
+                                            <Badge className="bg-green-100 text-xs text-green-800">100%</Badge> {/* Reduced text size */}
                                         </div>
-                                        <div className="flex items-center justify-between py-1"> {/* Reduced padding */}
+                                        <div className="flex items-center justify-between py-1">
+                                            {' '}
+                                            {/* Reduced padding */}
                                             <span className="text-sm text-gray-600">Performance Level</span>
                                             <Badge className={`${overallGrade.bg} ${overallGrade.color} text-xs`}>
-                                                {assessment.overall_score >= 80 ? 'Excellent' :
-                                                    assessment.overall_score >= 60 ? 'Good' : 'Needs Improvement'}
+                                                {assessment.overall_score >= 80
+                                                    ? 'Excellent'
+                                                    : assessment.overall_score >= 60
+                                                      ? 'Good'
+                                                      : 'Needs Improvement'}
                                             </Badge>
                                         </div>
-                                        <div className="flex items-center justify-between py-1"> {/* Reduced padding */}
+                                        <div className="flex items-center justify-between py-1">
+                                            {' '}
+                                            {/* Reduced padding */}
                                             <span className="text-sm text-gray-600">Assessment Type</span>
-                                            <Badge variant="outline" className="text-xs">Free Plan</Badge> {/* Reduced text size */}
+                                            <Badge variant="outline" className="text-xs">
+                                                Free Plan
+                                            </Badge>{' '}
+                                            {/* Reduced text size */}
                                         </div>
                                     </CardContent>
                                 </Card>
@@ -360,6 +386,10 @@ export default function Results({ assessment, statistics, domainScores, user, ca
 
                     .print\\:shadow-none {
                         box-shadow: none !important;
+                    }
+
+                    .print\\:p-0 {
+                        padding: 0 !important;
                     }
 
                     body {

--- a/resources/js/pages/FreeAssessment/Start.tsx
+++ b/resources/js/pages/FreeAssessment/Start.tsx
@@ -1,28 +1,28 @@
-import React, { useState, useEffect, useMemo } from 'react';
-import { Head, useForm, router } from '@inertiajs/react';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import AssessmentHeader from '@/components/assessment-header';
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Progress } from '@/components/ui/progress';
 import { Textarea } from '@/components/ui/textarea';
-import { Badge } from '@/components/ui/badge';
+import { useLanguage } from '@/hooks/use-language';
+import { Head, router, useForm } from '@inertiajs/react';
 import {
-    CheckCircle,
-    XCircle,
-    MinusCircle,
-    FileText,
+    ArrowUp,
     Award,
     BarChart3,
-    Upload,
-    File,
-    X,
-    Paperclip,
-    Cloud,
-    ArrowUp,
     CheckCheck,
+    CheckCircle,
     Clock,
-    Users
+    Cloud,
+    File,
+    FileText,
+    MinusCircle,
+    Paperclip,
+    Upload,
+    X,
+    XCircle,
 } from 'lucide-react';
-import { useLanguage } from '@/hooks/use-language';
+import { useEffect, useMemo, useState } from 'react';
 
 interface Criterion {
     id: number;
@@ -101,7 +101,7 @@ export default function Start({ assessmentData, locale, auth, existingNotes }: T
                 });
             }
             return initial;
-        }
+        },
     );
     const [notes, setNotes] = useState<Record<number, string>>(existingNotes || {});
     const [files, setFiles] = useState<Record<number, File | null>>({});
@@ -112,21 +112,21 @@ export default function Start({ assessmentData, locale, auth, existingNotes }: T
     const { data, setData, processing } = useForm({
         responses: {},
         notes: {},
-        files: {}
+        files: {},
     });
 
     // Flatten all criteria into a single array with domain and category info
     const allCriteria = useMemo(() => {
         const criteria: (Criterion & { domainName: string; categoryName: string; domainId: number; categoryId: number })[] = [];
-        assessmentData.tool.domains.forEach(domain => {
-            domain.categories.forEach(category => {
-                category.criteria.forEach(criterion => {
+        assessmentData.tool.domains.forEach((domain) => {
+            domain.categories.forEach((category) => {
+                category.criteria.forEach((criterion) => {
                     criteria.push({
                         ...criterion,
                         domainName: language === 'ar' ? domain.name_ar : domain.name_en,
                         categoryName: language === 'ar' ? category.name_ar : category.name_en,
                         domainId: domain.id,
-                        categoryId: category.id
+                        categoryId: category.id,
                     });
                 });
             });
@@ -144,71 +144,68 @@ export default function Start({ assessmentData, locale, auth, existingNotes }: T
 
     // Check if assessment is complete
     const isComplete = useMemo(() => {
-        return allCriteria.every(criterion => {
+        return allCriteria.every((criterion) => {
             const hasResponse = responses[criterion.id];
-            const hasRequiredFile = !criterion.requires_file ||
-                responses[criterion.id] !== 'yes' ||
-                files[criterion.id];
+            const hasRequiredFile = !criterion.requires_file || responses[criterion.id] !== 'yes' || files[criterion.id];
             return hasResponse && hasRequiredFile;
         });
     }, [responses, files, allCriteria]);
 
-
     const t = {
         en: {
-            assessment: "Assessment",
-            question: "Question",
-            of: "of",
-            yes: "Yes",
-            no: "No",
-            notApplicable: "Not Applicable",
-            notes: "Notes (Optional)",
-            notesPlaceholder: "Add any notes or comments...",
-            complete: "Complete",
-            completed: "Completed",
-            remaining: "Remaining",
-            progress: "Progress",
-            submitAssessment: "Submit Assessment",
-            assessmentComplete: "Assessment Complete!",
-            submitting: "Submitting...",
-            totalQuestions: "Total Questions",
-            attachmentRequired: "Attachment Required",
-            uploadFile: "Upload Supporting Document",
-            changeFile: "Change File",
-            removeFile: "Remove File",
-            dragDropFile: "Drag and drop a file here, or click to select",
-            fileUploaded: "File uploaded successfully",
-            scrollToTop: "Scroll to top",
+            assessment: 'Assessment',
+            question: 'Question',
+            of: 'of',
+            yes: 'Yes',
+            no: 'No',
+            notApplicable: 'Not Applicable',
+            notes: 'Notes (Optional)',
+            notesPlaceholder: 'Add any notes or comments...',
+            complete: 'Complete',
+            completed: 'Completed',
+            remaining: 'Remaining',
+            progress: 'Progress',
+            submitAssessment: 'Submit Assessment',
+            assessmentComplete: 'Assessment Complete!',
+            submitting: 'Submitting...',
+            totalQuestions: 'Total Questions',
+            attachmentRequired: 'Attachment Required',
+            uploadFile: 'Upload Supporting Document',
+            changeFile: 'Change File',
+            removeFile: 'Remove File',
+            dragDropFile: 'Drag and drop a file here, or click to select',
+            fileUploaded: 'File uploaded successfully',
+            scrollToTop: 'Scroll to top',
             startAssessment: "Let's get started with your assessment",
-            welcomeMessage: "Please answer all questions honestly and provide any required documentation."
+            welcomeMessage: 'Please answer all questions honestly and provide any required documentation.',
         },
         ar: {
-            assessment: "التقييم",
-            question: "السؤال",
-            of: "من",
-            yes: "نعم",
-            no: "لا",
-            notApplicable: "غير قابل للتطبيق",
-            notes: "ملاحظات (اختياري)",
-            notesPlaceholder: "أضف أي ملاحظات أو تعليقات...",
-            complete: "مكتمل",
-            completed: "مكتمل",
-            remaining: "متبقي",
-            progress: "التقدم",
-            submitAssessment: "إرسال التقييم",
-            assessmentComplete: "اكتمل التقييم!",
-            submitting: "جاري الإرسال...",
-            totalQuestions: "إجمالي الأسئلة",
-            attachmentRequired: "مرفق مطلوب",
-            uploadFile: "رفع وثيقة داعمة",
-            changeFile: "تغيير الملف",
-            removeFile: "إزالة الملف",
-            dragDropFile: "اسحب وأفلت ملفًا هنا، أو انقر للاختيار",
-            fileUploaded: "تم رفع الملف بنجاح",
-            scrollToTop: "التمرير إلى الأعلى",
-            startAssessment: "لنبدأ بتقييمك",
-            welcomeMessage: "يرجى الإجابة على جميع الأسئلة بصدق وتقديم أي وثائق مطلوبة."
-        }
+            assessment: 'التقييم',
+            question: 'السؤال',
+            of: 'من',
+            yes: 'نعم',
+            no: 'لا',
+            notApplicable: 'غير قابل للتطبيق',
+            notes: 'ملاحظات (اختياري)',
+            notesPlaceholder: 'أضف أي ملاحظات أو تعليقات...',
+            complete: 'مكتمل',
+            completed: 'مكتمل',
+            remaining: 'متبقي',
+            progress: 'التقدم',
+            submitAssessment: 'إرسال التقييم',
+            assessmentComplete: 'اكتمل التقييم!',
+            submitting: 'جاري الإرسال...',
+            totalQuestions: 'إجمالي الأسئلة',
+            attachmentRequired: 'مرفق مطلوب',
+            uploadFile: 'رفع وثيقة داعمة',
+            changeFile: 'تغيير الملف',
+            removeFile: 'إزالة الملف',
+            dragDropFile: 'اسحب وأفلت ملفًا هنا، أو انقر للاختيار',
+            fileUploaded: 'تم رفع الملف بنجاح',
+            scrollToTop: 'التمرير إلى الأعلى',
+            startAssessment: 'لنبدأ بتقييمك',
+            welcomeMessage: 'يرجى الإجابة على جميع الأسئلة بصدق وتقديم أي وثائق مطلوبة.',
+        },
     }[language];
 
     // Handle scroll to show/hide scroll to top button
@@ -221,25 +218,25 @@ export default function Start({ assessmentData, locale, auth, existingNotes }: T
     }, []);
 
     const handleResponseChange = (criterionId: number, response: 'yes' | 'no' | 'na') => {
-        setResponses(prev => ({ ...prev, [criterionId]: response }));
+        setResponses((prev) => ({ ...prev, [criterionId]: response }));
 
         // Clear file if response is not 'yes' for criteria requiring files
-        const criterion = allCriteria.find(c => c.id === criterionId);
+        const criterion = allCriteria.find((c) => c.id === criterionId);
         if (criterion?.requires_file && response !== 'yes') {
-            setFiles(prev => ({ ...prev, [criterionId]: null }));
+            setFiles((prev) => ({ ...prev, [criterionId]: null }));
         }
     };
 
     const handleNotesChange = (criterionId: number, value: string) => {
-        setNotes(prev => ({ ...prev, [criterionId]: value }));
+        setNotes((prev) => ({ ...prev, [criterionId]: value }));
     };
 
     const handleFileUpload = (criterionId: number, file: File) => {
-        setFiles(prev => ({ ...prev, [criterionId]: file }));
+        setFiles((prev) => ({ ...prev, [criterionId]: file }));
     };
 
     const handleFileRemove = (criterionId: number) => {
-        setFiles(prev => ({ ...prev, [criterionId]: null }));
+        setFiles((prev) => ({ ...prev, [criterionId]: null }));
     };
 
     const submitAssessment = () => {
@@ -254,93 +251,69 @@ export default function Start({ assessmentData, locale, auth, existingNotes }: T
 
         // Wait a tick to ensure state updates (if needed)
         setTimeout(() => {
-            router.post(
-                route('free-assessment.submit', assessmentData.id),
-                { responses, notes, files },
-                { forceFormData: true }
-            );
+            router.post(route('free-assessment.submit', assessmentData.id), { responses, notes, files }, { forceFormData: true });
         }, 0);
     };
-
 
     const scrollToTop = () => {
         window.scrollTo({ top: 0, behavior: 'smooth' });
     };
 
-
     return (
         <>
             <Head title={`${assessmentData.tool.name_en} ${t.assessment}`} />
 
-            <div className={`min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50 ${language === 'ar' ? 'rtl' : 'ltr'}`} dir={language === 'ar' ? 'rtl' : 'ltr'}>
-
-                {/* Fixed Header */}
-                <header className="bg-white/95 backdrop-blur-md shadow-lg border-b border-blue-200/50 sticky top-0 z-50">
-                    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-                        <div className="flex justify-between items-center h-20">
-                            <div className="flex items-center space-x-6">
-                                <img
-                                    src="/storage/logo.svg"
-                                    alt="FAQ Logo"
-                                    className="bg-transparent h-12 w-auto object-contain hover:scale-105 transition-transform duration-200"
-                                />
-                                <div className="h-8 w-px bg-gray-300"></div>
-                                <div>
-                                    <h1 className="text-2xl font-bold text-gray-900">
-                                        {language === 'ar' ? assessmentData.tool.name_ar : assessmentData.tool.name_en}
-                                    </h1>
-                                    <div className="flex items-center space-x-2 text-sm text-gray-600">
-                                        <Users className="w-4 h-4" />
-                                        <span>{auth.user.name}</span>
-                                    </div>
+            <div
+                className={`min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-50 ${language === 'ar' ? 'rtl' : 'ltr'}`}
+                dir={language === 'ar' ? 'rtl' : 'ltr'}
+            >
+                <AssessmentHeader
+                    title={language === 'ar' ? assessmentData.tool.name_ar : assessmentData.tool.name_en}
+                    userName={auth.user.name}
+                    rightContent={
+                        <div className="hidden items-center space-x-4 rounded-full bg-blue-50 px-6 py-3 md:flex">
+                            <BarChart3 className="h-5 w-5 text-blue-600" />
+                            <div className="text-right">
+                                <div className="text-lg font-bold text-blue-900">{Math.round(completionPercentage)}%</div>
+                                <div className="text-xs text-blue-700">
+                                    {Object.keys(responses).length}/{totalCriteria}
                                 </div>
                             </div>
-                            <div className="flex items-center space-x-6">
-                                <div className="hidden md:flex items-center space-x-4 bg-blue-50 rounded-full px-6 py-3">
-                                    <BarChart3 className="w-5 h-5 text-blue-600" />
-                                    <div className="text-right">
-                                        <div className="text-lg font-bold text-blue-900">{Math.round(completionPercentage)}%</div>
-                                        <div className="text-xs text-blue-700">{Object.keys(responses).length}/{totalCriteria}</div>
-                                    </div>
-                                    <Progress value={completionPercentage} className="w-24 h-2" />
-                                </div>
-
-                            </div>
+                            <Progress value={completionPercentage} className="h-2 w-24" />
                         </div>
-                    </div>
-                </header>
+                    }
+                />
 
                 {/* Welcome Section */}
-                <div className="py-12 px-4 sm:px-6 lg:px-8">
-                    <div className="max-w-4xl mx-auto">
-                        <Card className="mb-8 border-0 shadow-2xl bg-gradient-to-br from-blue-600 via-purple-600 to-indigo-700 text-white overflow-hidden">
-
+                <div className="px-4 py-12 sm:px-6 lg:px-8">
+                    <div className="mx-auto max-w-4xl">
+                        <Card className="mb-8 overflow-hidden border-0 bg-gradient-to-br from-blue-600 via-purple-600 to-indigo-700 text-white shadow-2xl">
                             <CardContent className="relative p-8 md:p-12">
                                 <div className="text-center">
-                                    <div className="flex items-center justify-center mb-6">
-                                        <div className="w-16 h-16 bg-white/20 rounded-full flex items-center justify-center">
-                                            <FileText className="w-8 h-8" />
+                                    <div className="mb-6 flex items-center justify-center">
+                                        <div className="flex h-16 w-16 items-center justify-center rounded-full bg-white/20">
+                                            <FileText className="h-8 w-8" />
                                         </div>
                                     </div>
-                                    <h2 className="text-3xl md:text-4xl font-bold mb-4">{t.startAssessment}</h2>
-                                    <p className="text-xl text-blue-100 mb-8 max-w-2xl mx-auto">{t.welcomeMessage}</p>
+                                    <h2 className="mb-4 text-3xl font-bold md:text-4xl">{t.startAssessment}</h2>
+                                    <p className="mx-auto mb-8 max-w-2xl text-xl text-blue-100">{t.welcomeMessage}</p>
 
-                                    <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
-                                        <div className="text-center p-4 bg-white/10 rounded-xl backdrop-blur-sm">
+                                    <div className="mb-8 grid grid-cols-1 gap-6 md:grid-cols-3">
+                                        <div className="rounded-xl bg-white/10 p-4 text-center backdrop-blur-sm">
                                             <div className="text-3xl font-bold">{totalCriteria}</div>
                                             <div className="text-blue-100">{t.totalQuestions}</div>
                                         </div>
-                                        <div className="text-center p-4 bg-white/10 rounded-xl backdrop-blur-sm">
+                                        <div className="rounded-xl bg-white/10 p-4 text-center backdrop-blur-sm">
                                             <div className="text-3xl font-bold">{Object.keys(responses).length}</div>
                                             <div className="text-blue-100">{t.completed}</div>
                                         </div>
-                                        <div className="text-center p-4 bg-white/10 rounded-xl backdrop-blur-sm">
+                                        <div className="rounded-xl bg-white/10 p-4 text-center backdrop-blur-sm">
                                             <div className="text-3xl font-bold">{Math.round(completionPercentage)}%</div>
                                             <div className="text-blue-100">{t.progress}</div>
                                         </div>
                                     </div>
 
-                                    <Progress value={completionPercentage} className="bg-white/20 h-3 mb-4" />
+                                    <Progress value={completionPercentage} className="mb-4 h-3 bg-white/20" />
                                 </div>
                             </CardContent>
                         </Card>
@@ -350,22 +323,22 @@ export default function Start({ assessmentData, locale, auth, existingNotes }: T
                             {allCriteria.map((criterion, index) => (
                                 <Card
                                     key={criterion.id}
-                                    className="border-0 shadow-xl hover:shadow-2xl transition-all duration-300 transform hover:-translate-y-1"
+                                    className="transform border-0 shadow-xl transition-all duration-300 hover:-translate-y-1 hover:shadow-2xl"
                                 >
-                                    <CardHeader className="bg-gradient-to-r from-gray-50 to-blue-50 border-b border-blue-100">
+                                    <CardHeader className="border-b border-blue-100 bg-gradient-to-r from-gray-50 to-blue-50">
                                         <div className="flex items-start justify-between">
-                                            <div className="flex items-start space-x-4 flex-1">
-                                                <div className="w-10 h-10 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-bold flex-shrink-0">
+                                            <div className="flex flex-1 items-start space-x-4">
+                                                <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-blue-600 text-sm font-bold text-white">
                                                     {index + 1}
                                                 </div>
                                                 <div className="flex-1">
-                                                    <CardTitle className="text-lg leading-relaxed text-gray-900 mb-3">
+                                                    <CardTitle className="mb-3 text-lg leading-relaxed text-gray-900">
                                                         {language === 'ar' ? criterion.text_ar : criterion.text_en}
                                                     </CardTitle>
                                                     <div className="flex items-center space-x-2">
                                                         {criterion.requires_file && (
-                                                            <Badge variant="secondary" className="bg-amber-100 text-amber-800 border-amber-200">
-                                                                <Paperclip className="w-3 h-3 mr-1" />
+                                                            <Badge variant="secondary" className="border-amber-200 bg-amber-100 text-amber-800">
+                                                                <Paperclip className="mr-1 h-3 w-3" />
                                                                 {t.attachmentRequired}
                                                             </Badge>
                                                         )}
@@ -376,11 +349,11 @@ export default function Start({ assessmentData, locale, auth, existingNotes }: T
                                                                     responses[criterion.id] === 'yes'
                                                                         ? 'bg-green-100 text-green-800'
                                                                         : responses[criterion.id] === 'no'
-                                                                        ? 'bg-red-100 text-red-800'
-                                                                        : 'bg-gray-100 text-gray-800'
+                                                                          ? 'bg-red-100 text-red-800'
+                                                                          : 'bg-gray-100 text-gray-800'
                                                                 }
                                                             >
-                                                                <CheckCheck className="w-3 h-3 mr-1" />
+                                                                <CheckCheck className="mr-1 h-3 w-3" />
                                                                 Answered
                                                             </Badge>
                                                         )}
@@ -388,16 +361,10 @@ export default function Start({ assessmentData, locale, auth, existingNotes }: T
                                                 </div>
                                             </div>
                                             {responses[criterion.id] && (
-                                                <div className="flex items-center ml-4">
-                                                    {responses[criterion.id] === 'yes' && (
-                                                        <CheckCircle className="w-8 h-8 text-green-600" />
-                                                    )}
-                                                    {responses[criterion.id] === 'no' && (
-                                                        <XCircle className="w-8 h-8 text-red-600" />
-                                                    )}
-                                                    {responses[criterion.id] === 'na' && (
-                                                        <MinusCircle className="w-8 h-8 text-gray-600" />
-                                                    )}
+                                                <div className="ml-4 flex items-center">
+                                                    {responses[criterion.id] === 'yes' && <CheckCircle className="h-8 w-8 text-green-600" />}
+                                                    {responses[criterion.id] === 'no' && <XCircle className="h-8 w-8 text-red-600" />}
+                                                    {responses[criterion.id] === 'na' && <MinusCircle className="h-8 w-8 text-gray-600" />}
                                                 </div>
                                             )}
                                         </div>
@@ -406,19 +373,19 @@ export default function Start({ assessmentData, locale, auth, existingNotes }: T
                                     <CardContent className="p-8">
                                         <div className="space-y-6">
                                             {/* Response Buttons */}
-                                            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                                            <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
                                                 <Button
                                                     variant={responses[criterion.id] === 'yes' ? 'default' : 'outline'}
                                                     size="lg"
                                                     onClick={() => handleResponseChange(criterion.id, 'yes')}
-                                                    className={`h-16 transition-all duration-300 transform hover:scale-105 ${
+                                                    className={`h-16 transform transition-all duration-300 hover:scale-105 ${
                                                         responses[criterion.id] === 'yes'
-                                                            ? 'bg-green-600 hover:bg-green-700 text-white shadow-lg shadow-green-200'
-                                                            : 'hover:bg-green-50 hover:border-green-300 hover:shadow-lg'
+                                                            ? 'bg-green-600 text-white shadow-lg shadow-green-200 hover:bg-green-700'
+                                                            : 'hover:border-green-300 hover:bg-green-50 hover:shadow-lg'
                                                     }`}
                                                 >
                                                     <div className="flex items-center space-x-3">
-                                                        <CheckCircle className="w-6 h-6" />
+                                                        <CheckCircle className="h-6 w-6" />
                                                         <span className="text-lg font-medium">{t.yes}</span>
                                                     </div>
                                                 </Button>
@@ -426,14 +393,14 @@ export default function Start({ assessmentData, locale, auth, existingNotes }: T
                                                     variant={responses[criterion.id] === 'no' ? 'default' : 'outline'}
                                                     size="lg"
                                                     onClick={() => handleResponseChange(criterion.id, 'no')}
-                                                    className={`h-16 transition-all duration-300 transform hover:scale-105 ${
+                                                    className={`h-16 transform transition-all duration-300 hover:scale-105 ${
                                                         responses[criterion.id] === 'no'
-                                                            ? 'bg-red-600 hover:bg-red-700 text-white shadow-lg shadow-red-200'
-                                                            : 'hover:bg-red-50 hover:border-red-300 hover:shadow-lg'
+                                                            ? 'bg-red-600 text-white shadow-lg shadow-red-200 hover:bg-red-700'
+                                                            : 'hover:border-red-300 hover:bg-red-50 hover:shadow-lg'
                                                     }`}
                                                 >
                                                     <div className="flex items-center space-x-3">
-                                                        <XCircle className="w-6 h-6" />
+                                                        <XCircle className="h-6 w-6" />
                                                         <span className="text-lg font-medium">{t.no}</span>
                                                     </div>
                                                 </Button>
@@ -441,14 +408,14 @@ export default function Start({ assessmentData, locale, auth, existingNotes }: T
                                                     variant={responses[criterion.id] === 'na' ? 'default' : 'outline'}
                                                     size="lg"
                                                     onClick={() => handleResponseChange(criterion.id, 'na')}
-                                                    className={`h-16 transition-all duration-300 transform hover:scale-105 ${
+                                                    className={`h-16 transform transition-all duration-300 hover:scale-105 ${
                                                         responses[criterion.id] === 'na'
-                                                            ? 'bg-gray-600 hover:bg-gray-700 text-white shadow-lg shadow-gray-200'
-                                                            : 'hover:bg-gray-50 hover:border-gray-300 hover:shadow-lg'
+                                                            ? 'bg-gray-600 text-white shadow-lg shadow-gray-200 hover:bg-gray-700'
+                                                            : 'hover:border-gray-300 hover:bg-gray-50 hover:shadow-lg'
                                                     }`}
                                                 >
                                                     <div className="flex items-center space-x-3">
-                                                        <MinusCircle className="w-6 h-6" />
+                                                        <MinusCircle className="h-6 w-6" />
                                                         <span className="text-lg font-medium">{t.notApplicable}</span>
                                                     </div>
                                                 </Button>
@@ -456,10 +423,10 @@ export default function Start({ assessmentData, locale, auth, existingNotes }: T
 
                                             {/* File Upload Section - Only show when requires_file is true AND response is 'yes' */}
                                             {criterion.requires_file && responses[criterion.id] === 'yes' && (
-                                                <div className="space-y-4 p-6 bg-gradient-to-br from-blue-50 to-indigo-50 border-2 border-blue-200 rounded-xl">
-                                                    <div className="flex items-center space-x-3 mb-4">
-                                                        <div className="w-10 h-10 bg-blue-600 rounded-lg flex items-center justify-center">
-                                                            <Upload className="w-5 h-5 text-white" />
+                                                <div className="space-y-4 rounded-xl border-2 border-blue-200 bg-gradient-to-br from-blue-50 to-indigo-50 p-6">
+                                                    <div className="mb-4 flex items-center space-x-3">
+                                                        <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-blue-600">
+                                                            <Upload className="h-5 w-5 text-white" />
                                                         </div>
                                                         <div>
                                                             <h4 className="text-lg font-semibold text-blue-900">{t.uploadFile}</h4>
@@ -472,45 +439,47 @@ export default function Start({ assessmentData, locale, auth, existingNotes }: T
                                                             <input
                                                                 type="file"
                                                                 id={`file-${criterion.id}`}
-                                                                className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
+                                                                className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
                                                                 onChange={(e) => {
                                                                     const file = e.target.files?.[0];
                                                                     if (file) handleFileUpload(criterion.id, file);
                                                                 }}
                                                                 accept=".pdf,.doc,.docx,.jpg,.jpeg,.png"
                                                             />
-                                                            <div className="border-2 border-dashed border-blue-300 rounded-xl p-8 text-center hover:border-blue-400 hover:bg-blue-25 transition-all duration-300 cursor-pointer group">
-                                                                <Cloud className="w-16 h-16 text-blue-400 mx-auto mb-4 group-hover:scale-110 transition-transform duration-200" />
-                                                                <p className="text-blue-800 font-medium mb-2 text-lg">{t.dragDropFile}</p>
+                                                            <div className="hover:bg-blue-25 group cursor-pointer rounded-xl border-2 border-dashed border-blue-300 p-8 text-center transition-all duration-300 hover:border-blue-400">
+                                                                <Cloud className="mx-auto mb-4 h-16 w-16 text-blue-400 transition-transform duration-200 group-hover:scale-110" />
+                                                                <p className="mb-2 text-lg font-medium text-blue-800">{t.dragDropFile}</p>
                                                                 <p className="text-blue-600">PDF, DOC, DOCX, JPG, PNG (Max 10MB)</p>
                                                             </div>
                                                         </div>
                                                     ) : (
-                                                        <div className="bg-white border-2 border-blue-200 rounded-xl p-6 shadow-lg">
+                                                        <div className="rounded-xl border-2 border-blue-200 bg-white p-6 shadow-lg">
                                                             <div className="flex items-center justify-between">
                                                                 <div className="flex items-center space-x-4">
-                                                                    <div className="w-12 h-12 bg-green-100 rounded-xl flex items-center justify-center">
-                                                                        <File className="w-6 h-6 text-green-600" />
+                                                                    <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-green-100">
+                                                                        <File className="h-6 w-6 text-green-600" />
                                                                     </div>
                                                                     <div>
-                                                                        <p className="font-semibold text-gray-900 text-lg">{files[criterion.id]?.name}</p>
+                                                                        <p className="text-lg font-semibold text-gray-900">
+                                                                            {files[criterion.id]?.name}
+                                                                        </p>
                                                                         <p className="text-sm text-gray-500">
                                                                             {((files[criterion.id]?.size || 0) / 1024 / 1024).toFixed(2)} MB
                                                                         </p>
                                                                     </div>
                                                                 </div>
                                                                 <div className="flex items-center space-x-3">
-                                                                    <Badge variant="secondary" className="bg-green-100 text-green-800 px-3 py-1">
-                                                                        <CheckCircle className="w-4 h-4 mr-1" />
+                                                                    <Badge variant="secondary" className="bg-green-100 px-3 py-1 text-green-800">
+                                                                        <CheckCircle className="mr-1 h-4 w-4" />
                                                                         {t.fileUploaded}
                                                                     </Badge>
                                                                     <Button
                                                                         variant="ghost"
                                                                         size="sm"
                                                                         onClick={() => handleFileRemove(criterion.id)}
-                                                                        className="text-red-600 hover:text-red-700 hover:bg-red-50 p-2"
+                                                                        className="p-2 text-red-600 hover:bg-red-50 hover:text-red-700"
                                                                     >
-                                                                        <X className="w-4 h-4" />
+                                                                        <X className="h-4 w-4" />
                                                                     </Button>
                                                                 </div>
                                                             </div>
@@ -521,9 +490,9 @@ export default function Start({ assessmentData, locale, auth, existingNotes }: T
 
                                             {/* Notes Section */}
                                             {responses[criterion.id] && (
-                                                <div className="space-y-4 p-6 bg-gray-50 border border-gray-200 rounded-xl">
+                                                <div className="space-y-4 rounded-xl border border-gray-200 bg-gray-50 p-6">
                                                     <div className="flex items-center space-x-2">
-                                                        <FileText className="w-5 h-5 text-gray-600" />
+                                                        <FileText className="h-5 w-5 text-gray-600" />
                                                         <label className="text-base font-medium text-gray-900">{t.notes}</label>
                                                     </div>
                                                     <Textarea
@@ -531,7 +500,7 @@ export default function Start({ assessmentData, locale, auth, existingNotes }: T
                                                         onChange={(e) => handleNotesChange(criterion.id, e.target.value)}
                                                         placeholder={t.notesPlaceholder}
                                                         rows={3}
-                                                        className="resize-none text-base border-gray-300 focus:border-blue-500 focus:ring-blue-500"
+                                                        className="resize-none border-gray-300 text-base focus:border-blue-500 focus:ring-blue-500"
                                                     />
                                                 </div>
                                             )}
@@ -543,29 +512,29 @@ export default function Start({ assessmentData, locale, auth, existingNotes }: T
 
                         {/* Submit Assessment */}
                         {isComplete && (
-                            <Card className="mt-12 border-0 shadow-2xl bg-gradient-to-br from-green-600 via-emerald-600 to-teal-600 text-white">
+                            <Card className="mt-12 border-0 bg-gradient-to-br from-green-600 via-emerald-600 to-teal-600 text-white shadow-2xl">
                                 <CardContent className="p-12 text-center">
                                     <div className="space-y-8">
                                         <div className="flex items-center justify-center">
-                                            <div className="w-24 h-24 bg-white/20 rounded-full flex items-center justify-center mb-6 animate-pulse">
-                                                <Award className="w-12 h-12" />
+                                            <div className="mb-6 flex h-24 w-24 animate-pulse items-center justify-center rounded-full bg-white/20">
+                                                <Award className="h-12 w-12" />
                                             </div>
                                         </div>
 
                                         <div>
-                                            <h3 className="text-4xl font-bold mb-4">{t.assessmentComplete}</h3>
-                                            <p className="text-green-100 text-xl mb-8 max-w-2xl mx-auto">
+                                            <h3 className="mb-4 text-4xl font-bold">{t.assessmentComplete}</h3>
+                                            <p className="mx-auto mb-8 max-w-2xl text-xl text-green-100">
                                                 Congratulations! You have successfully completed all {totalCriteria} questions with excellence.
                                             </p>
                                         </div>
 
-                                        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
-                                            <div className="text-center p-6 bg-white/10 rounded-2xl backdrop-blur-sm">
-                                                <div className="text-4xl font-bold mb-2">{totalCriteria}</div>
+                                        <div className="mb-8 grid grid-cols-1 gap-6 md:grid-cols-2">
+                                            <div className="rounded-2xl bg-white/10 p-6 text-center backdrop-blur-sm">
+                                                <div className="mb-2 text-4xl font-bold">{totalCriteria}</div>
                                                 <div className="text-green-100">{t.totalQuestions}</div>
                                             </div>
-                                            <div className="text-center p-6 bg-white/10 rounded-2xl backdrop-blur-sm">
-                                                <div className="text-4xl font-bold mb-2">100%</div>
+                                            <div className="rounded-2xl bg-white/10 p-6 text-center backdrop-blur-sm">
+                                                <div className="mb-2 text-4xl font-bold">100%</div>
                                                 <div className="text-green-100">{t.complete}</div>
                                             </div>
                                         </div>
@@ -574,16 +543,16 @@ export default function Start({ assessmentData, locale, auth, existingNotes }: T
                                             onClick={submitAssessment}
                                             size="lg"
                                             disabled={processing}
-                                            className="bg-white text-green-600 hover:bg-gray-100 px-12 py-6 text-xl font-bold shadow-2xl transform hover:scale-105 transition-all duration-300"
+                                            className="transform bg-white px-12 py-6 text-xl font-bold text-green-600 shadow-2xl transition-all duration-300 hover:scale-105 hover:bg-gray-100"
                                         >
                                             {processing ? (
                                                 <>
-                                                    <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-green-600 mr-4"></div>
+                                                    <div className="mr-4 h-6 w-6 animate-spin rounded-full border-b-2 border-green-600"></div>
                                                     {t.submitting}
                                                 </>
                                             ) : (
                                                 <>
-                                                    <Award className="w-6 h-6 mr-3" />
+                                                    <Award className="mr-3 h-6 w-6" />
                                                     {t.submitAssessment}
                                                 </>
                                             )}
@@ -595,15 +564,15 @@ export default function Start({ assessmentData, locale, auth, existingNotes }: T
 
                         {/* Floating Progress Indicator */}
                         {!isComplete && (
-                            <div className="fixed bottom-6 right-6 z-50">
-                                <Card className="bg-white/95 backdrop-blur-sm shadow-2xl border-0 p-4">
+                            <div className="fixed right-6 bottom-6 z-50">
+                                <Card className="border-0 bg-white/95 p-4 shadow-2xl backdrop-blur-sm">
                                     <div className="flex items-center space-x-3">
-                                        <Clock className="w-5 h-5 text-blue-600" />
+                                        <Clock className="h-5 w-5 text-blue-600" />
                                         <div>
                                             <div className="text-sm font-medium text-gray-900">
                                                 {Object.keys(responses).length} / {totalCriteria}
                                             </div>
-                                            <Progress value={completionPercentage} className="w-24 h-2" />
+                                            <Progress value={completionPercentage} className="h-2 w-24" />
                                         </div>
                                     </div>
                                 </Card>
@@ -614,10 +583,10 @@ export default function Start({ assessmentData, locale, auth, existingNotes }: T
                         {showScrollTop && (
                             <Button
                                 onClick={scrollToTop}
-                                className="fixed bottom-6 left-6 z-50 w-12 h-12 rounded-full bg-blue-600 hover:bg-blue-700 shadow-2xl"
+                                className="fixed bottom-6 left-6 z-50 h-12 w-12 rounded-full bg-blue-600 shadow-2xl hover:bg-blue-700"
                                 size="sm"
                             >
-                                <ArrowUp className="w-5 h-5" />
+                                <ArrowUp className="h-5 w-5" />
                             </Button>
                         )}
                     </div>


### PR DESCRIPTION
## Summary
- add shared `AssessmentHeader` component with language switch
- enhance Free Assessment pages with new header and translations
- show spinner on completion page and auto-redirect
- adjust results page header and print styles

## Testing
- `npm run format`
- `npm run lint` *(fails: 69 errors)*
- `npm run types` *(fails: TS1149 duplicate file name)*

------
https://chatgpt.com/codex/tasks/task_e_68773da59cf48331a71f2a88df201604