### PR TITLE
Ensure single free assessment per tool

### DIFF
--- a/app/Http/Controllers/FreeAssessmentController.php
+++ b/app/Http/Controllers/FreeAssessmentController.php
@@ -247,6 +247,13 @@ class FreeAssessmentController extends Controller
         try {
             DB::beginTransaction();
 
+            // Remove any previous free assessments for this tool
+            Assessment::where('user_id', $user->id)
+                ->where('tool_id', $assessment->tool_id)
+                ->where('id', '!=', $assessment->id)
+                ->where('assessment_type', 'free')
+                ->delete();
+
             // Clear existing responses to avoid duplicates
             $assessment->responses()->delete();
 


### PR DESCRIPTION
## Summary
- revert previous FreeUserController changes
- delete other free assessments for the same tool during free assessment submit

## Testing
- `composer test` *(fails: MissingAppKeyException)*

------
https://chatgpt.com/codex/tasks/task_e_6877beece3488331b733f88c90dc830d