### PR TITLE
Add tool request page for free assessments

### DIFF
--- a/app/Http/Controllers/FreeAssessmentController.php
+++ b/app/Http/Controllers/FreeAssessmentController.php
@@ -69,6 +69,28 @@ class FreeAssessmentController extends Controller
     }
 
     /**
+     * Show tool request form for a specific tool
+     */
+    public function requestForm(Tool $tool)
+    {
+        return Inertia::render('FreeAssessment/ToolRequest', [
+            'tool' => [
+                'id' => $tool->id,
+                'name_en' => $tool->name_en,
+                'name_ar' => $tool->name_ar,
+                'description_en' => $tool->description_en,
+                'description_ar' => $tool->description_ar,
+                'image' => $tool->image,
+            ],
+            'user' => auth()->user() ? [
+                'name' => auth()->user()->name,
+                'email' => auth()->user()->email,
+                'organization' => auth()->user()->getCompanyName(),
+            ] : null,
+        ]);
+    }
+
+    /**
      * Start or resume assessment
      */
     public function start(Request $request)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "Afaqcm",
+    "name": "afaqcm",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/resources/js/pages/FreeAssessment/ToolRequest.tsx
+++ b/resources/js/pages/FreeAssessment/ToolRequest.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import { Head, useForm, usePage } from '@inertiajs/react';
+import AppLayout from '@/layouts/app-layout';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Button } from '@/components/ui/button';
+import InputError from '@/components/input-error';
+import { useLanguage } from '@/hooks/use-language';
+
+interface ToolRequestProps {
+    tool: {
+        id: number;
+        name_en: string;
+        name_ar: string;
+        description_en?: string;
+        description_ar?: string;
+        image?: string;
+    };
+    user?: {
+        name: string;
+        email: string;
+        organization?: string;
+    } | null;
+}
+
+const translations = {
+    en: {
+        pageTitle: 'Request Tool Access',
+        name: 'Full Name',
+        email: 'Email',
+        organization: 'Organization (optional)',
+        message: 'Message',
+        submitting: 'Submitting...',
+        submit: 'Submit Request',
+    },
+    ar: {
+        pageTitle: 'طلب الوصول إلى الأداة',
+        name: 'الاسم الكامل',
+        email: 'البريد الإلكتروني',
+        organization: 'المنظمة (اختياري)',
+        message: 'رسالة',
+        submitting: 'جارٍ الإرسال...',
+        submit: 'إرسال الطلب',
+    },
+} as const;
+
+export default function ToolRequest({ tool, user }: ToolRequestProps) {
+    const { language } = useLanguage();
+    const t = translations[language];
+    const { flash } = usePage().props as any;
+    const { data, setData, post, processing, errors } = useForm({
+        tool_id: tool.id,
+        name: user?.name || '',
+        email: user?.email || '',
+        organization: user?.organization || '',
+        message: '',
+    });
+
+    const submit = (e: React.FormEvent) => {
+        e.preventDefault();
+        post('/tool-requests');
+    };
+
+    const toolName = language === 'ar' ? tool.name_ar : tool.name_en;
+    const toolDescription = language === 'ar' ? tool.description_ar : tool.description_en;
+
+    return (
+        <AppLayout>
+            <Head title={t.pageTitle} />
+            <div className="max-w-2xl mx-auto p-6 space-y-6">
+                {flash?.success && (
+                    <div className="p-4 bg-green-100 text-green-800 rounded">
+                        {flash.success}
+                    </div>
+                )}
+                <Card>
+                    <CardHeader>
+                        <CardTitle>{toolName}</CardTitle>
+                    </CardHeader>
+                    {tool.image && (
+                        <img src={tool.image} alt={toolName} className="w-full h-48 object-cover" />
+                    )}
+                    <CardContent>
+                        <p className="mb-4 text-gray-700">{toolDescription}</p>
+                        <form onSubmit={submit} className="space-y-4">
+                            <div className="space-y-2">
+                                <Label htmlFor="name">{t.name}</Label>
+                                <Input id="name" value={data.name} onChange={e => setData('name', e.target.value)} required />
+                                <InputError message={errors.name} />
+                            </div>
+                            <div className="space-y-2">
+                                <Label htmlFor="email">{t.email}</Label>
+                                <Input id="email" type="email" value={data.email} onChange={e => setData('email', e.target.value)} required />
+                                <InputError message={errors.email} />
+                            </div>
+                            <div className="space-y-2">
+                                <Label htmlFor="organization">{t.organization}</Label>
+                                <Input id="organization" value={data.organization} onChange={e => setData('organization', e.target.value)} />
+                                <InputError message={errors.organization} />
+                            </div>
+                            <div className="space-y-2">
+                                <Label htmlFor="message">{t.message}</Label>
+                                <Textarea id="message" value={data.message} onChange={e => setData('message', e.target.value)} rows={4} />
+                                <InputError message={errors.message} />
+                            </div>
+                            <Button type="submit" disabled={processing} className="w-full">
+                                {processing ? t.submitting : t.submit}
+                            </Button>
+                        </form>
+                    </CardContent>
+                </Card>
+            </div>
+        </AppLayout>
+    );
+}

--- a/resources/js/pages/ToolDiscover.tsx
+++ b/resources/js/pages/ToolDiscover.tsx
@@ -52,7 +52,7 @@ const translations = {
         freeAssessmentDesc: 'Try a complimentary assessment to see how our tools can help your organization grow.',
         freeAssessmentCTA: 'Start For Free',
         startAssessment: 'Start Assessment',
-        upgradeToPremium: 'Upgrade to Premium',
+        requestAccess: 'Request Access',
         requiresPremium: 'Premium Required',
         whyChooseTitle: 'Why Choose AFAQ?',
         feature1Title: 'Evidence-Based',
@@ -72,7 +72,7 @@ const translations = {
         freeAssessmentDesc: 'جرّب تقييمًا مجانيًا لترى كيف يمكن لأدواتنا أن تساعد مؤسستك على النمو.',
         freeAssessmentCTA: 'ابدأ مجانًا',
         startAssessment: 'ابدأ التقييم',
-        upgradeToPremium: 'الترقية إلى بريميوم',
+        requestAccess: 'طلب الوصول',
         requiresPremium: 'يتطلب بريميوم',
         whyChooseTitle: 'لماذا تختار آفاق؟',
         feature1Title: 'مبني على الأدلة',
@@ -125,11 +125,10 @@ const ToolCard = ({ tool, t, getName, getDescription }: { tool: Tool, t: any, ge
             <div className="p-6 flex flex-col flex-grow">
                 <p className="text-gray-600 mb-6 flex-grow">{getDescription(tool)}</p>
                 <Link
-                    href={tool.available ? '/assessment/' + tool.id : '/subscription'}
-                    disabled={!tool.available}
-                    className={`mt-auto block w-full py-3 px-4 rounded-lg font-semibold text-center text-white transition-all duration-300 ${!tool.available ? 'bg-gray-400 cursor-not-allowed' : `${colors.bg} ${colors.hoverBg} group-hover:shadow-lg group-hover:scale-105`}`}
+                    href={tool.available ? '/assessment/' + tool.id : `/free-assessment/request/${tool.id}`}
+                    className={`mt-auto block w-full py-3 px-4 rounded-lg font-semibold text-center text-white transition-all duration-300 ${colors.bg} ${colors.hoverBg} group-hover:shadow-lg group-hover:scale-105`}
                 >
-                    {tool.available ? t.startAssessment : t.upgradeToPremium}
+                    {tool.available ? t.startAssessment : t.requestAccess}
                 </Link>
             </div>
         </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -150,6 +150,10 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::get('/free-assessment', [FreeAssessmentController::class, 'index'])
             ->name('free-assessment.index');
 
+        // Request access to a tool
+        Route::get('/free-assessment/request/{tool}', [FreeAssessmentController::class, 'requestForm'])
+            ->name('free-assessment.request');
+
         // 2. Start assessment - NO PARAMETERS NEEDED (uses single free tool)
         Route::post('/free-assessment/start', [FreeAssessmentController::class, 'start'])
             ->name('free-assessment.start');


### PR DESCRIPTION
## Summary
- create new FreeAssessment ToolRequest page
- add controller method and route to render form
- link unavailable tools to the new request page

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `composer test` *(fails: MissingAppKeyException and other failures)*

------
https://chatgpt.com/codex/tasks/task_e_6877d29d30148331bd4f67ecae90f2c3