### PR TITLE
Simplify registration flow and add profile setup wizard

### DIFF
--- a/app/Http/Controllers/UserRegistrationController.php
+++ b/app/Http/Controllers/UserRegistrationController.php
@@ -32,17 +32,7 @@ class UserRegistrationController extends Controller
                 'name' => 'required|string|max:255',
                 'email' => 'required|string|email|max:255|unique:users,email',
                 'password' => 'required|string|min:8|confirmed',
-                'phone' => 'nullable|string|max:20',
-                'company_name' => 'nullable|string|max:255',
-                'position' => 'nullable|string|max:255',
-                'city' => 'nullable|string|max:255',
-                'website' => 'nullable|url|max:255',
-                'industry' => 'nullable|string|max:100',
-                'company_size' => 'nullable|string|max:100',
-                'how_did_you_hear' => 'nullable|string|max:255',
-                'marketing_emails' => 'boolean',
-                'newsletter_subscription' => 'boolean',
-                'agree_terms' => 'required|accepted',
+                'company_name' => 'required|string|max:255',
             ], [
                 'name.required' => 'Full name is required.',
                 'email.required' => 'Email address is required.',
@@ -51,9 +41,7 @@ class UserRegistrationController extends Controller
                 'password.required' => 'Password is required.',
                 'password.min' => 'Password must be at least 8 characters long.',
                 'password.confirmed' => 'Password confirmation does not match.',
-                'agree_terms.required' => 'You must agree to the terms and conditions.',
-                'agree_terms.accepted' => 'You must agree to the terms and conditions.',
-                'website.url' => 'Please enter a valid website URL.',
+                'company_name.required' => 'Company name is required.',
             ]);
 
             Log::info('Validation passed for user registration', ['email' => $validated['email']]);
@@ -83,18 +71,12 @@ class UserRegistrationController extends Controller
             try {
                 if (method_exists($user, 'details')) {
                     $user->details()->create([
-                        'organization' => $validated['company_name'] ?? 'Not specified',
-                        'phone' => $validated['phone'] ?? null,
-                        'company_name' => $validated['company_name'] ?? null,
-                        'position' => $validated['position'] ?? null,
-                        'city' => $validated['city'] ?? null,
-                        'website' => $validated['website'] ?? null,
-                        'industry' => $validated['industry'] ?? null,
-                        'company_size' => $validated['company_size'] ?? null,
-                        'how_did_you_hear' => $validated['how_did_you_hear'] ?? null,
-                        'marketing_emails' => $validated['marketing_emails'] ?? true,
-                        'newsletter_subscription' => $validated['newsletter_subscription'] ?? false,
+                        'company' => $validated['company_name'],
+                        'company_name' => $validated['company_name'],
                         'preferred_language' => app()->getLocale(),
+                        'marketing_emails' => true,
+                        'newsletter_subscription' => false,
+                        'profile_completed' => false,
                     ]);
                     Log::info('User details created', ['user_id' => $user->id]);
                 }
@@ -190,6 +172,29 @@ class UserRegistrationController extends Controller
                 'email' => 'Registration failed due to a system error. Please try again in a few moments.'
             ]);
         }
+    }
+
+    /**
+     * Complete user profile after initial registration
+     */
+    public function completeProfile(Request $request)
+    {
+        $data = $request->validate([
+            'phone' => ['required', 'string', 'max:255'],
+            'address' => ['required', 'string'],
+        ]);
+
+        $user = $request->user();
+
+        if ($user && $user->details) {
+            $user->details->update([
+                'phone' => $data['phone'],
+                'address' => $data['address'],
+                'profile_completed' => true,
+            ]);
+        }
+
+        return redirect()->route('dashboard');
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -435,6 +435,7 @@ class User extends Authenticatable implements FilamentUser
                 'preferred_language' => 'en',
                 'marketing_emails' => true,
                 'newsletter_subscription' => false,
+                'profile_completed' => false,
             ]);
         }
     }
@@ -454,6 +455,11 @@ class User extends Authenticatable implements FilamentUser
     {
         // Only if they have bought at least one tool or are admin
         return $this->hasAnyToolSubscription() || $this->isAdmin();
+    }
+
+    public function hasCompletedProfile(): bool
+    {
+        return (bool) ($this->details?->profile_completed);
     }
     public function hasAccessToTool(int $toolId): bool
     {

--- a/app/Models/UserDetails.php
+++ b/app/Models/UserDetails.php
@@ -35,6 +35,7 @@ class UserDetails extends Model
         'how_did_you_hear',
         'marketing_emails',
         'newsletter_subscription',
+        'profile_completed',
     ];
 
     protected $casts = [
@@ -45,6 +46,7 @@ class UserDetails extends Model
         'annual_revenue' => 'decimal:2',
         'established_year' => 'integer',
         'company_size' => 'integer',
+        'profile_completed' => 'boolean',
     ];
 
     /**

--- a/database/migrations/2025_08_03_083849_add_profile_completed_to_user_details_table.php
+++ b/database/migrations/2025_08_03_083849_add_profile_completed_to_user_details_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('user_details', function (Blueprint $table) {
+            $table->boolean('profile_completed')->default(false)->after('newsletter_subscription');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('user_details', function (Blueprint $table) {
+            $table->dropColumn('profile_completed');
+        });
+    }
+};

--- a/resources/js/components/ProfileWizard.tsx
+++ b/resources/js/components/ProfileWizard.tsx
@@ -1,0 +1,77 @@
+import { useState } from 'react';
+import { useForm } from '@inertiajs/react';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+
+interface ProfileWizardProps {
+  onComplete?: () => void;
+}
+
+const ProfileWizard = ({ onComplete }: ProfileWizardProps) => {
+  const [step, setStep] = useState(1);
+  const { data, setData, post, processing, errors } = useForm({
+    phone: '',
+    address: '',
+  });
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setData(name as 'phone' | 'address', value);
+  };
+
+  const nextStep = () => setStep((prev) => prev + 1);
+  const prevStep = () => setStep((prev) => prev - 1);
+
+  const handleSubmit = () => {
+    post(route('profile.complete'), {
+      onSuccess: () => {
+        if (onComplete) onComplete();
+      },
+    });
+  };
+
+  return (
+    <div>
+      {step === 1 && (
+        <div>
+          <h2 className="text-xl font-bold mb-4">Step 1: Personal Information</h2>
+          <Label htmlFor="phone" className="mb-2 block">Phone Number</Label>
+          <Input
+            id="phone"
+            name="phone"
+            placeholder="Phone Number"
+            value={data.phone}
+            onChange={handleChange}
+          />
+          {errors.phone && <div className="text-red-500 text-sm mt-1">{errors.phone}</div>}
+          <Button onClick={nextStep} className="mt-4" disabled={processing}>
+            Next
+          </Button>
+        </div>
+      )}
+      {step === 2 && (
+        <div>
+          <h2 className="text-xl font-bold mb-4">Step 2: Address Information</h2>
+          <Label htmlFor="address" className="mb-2 block">Address</Label>
+          <Input
+            id="address"
+            name="address"
+            placeholder="Address"
+            value={data.address}
+            onChange={handleChange}
+          />
+          {errors.address && <div className="text-red-500 text-sm mt-1">{errors.address}</div>}
+          <div className="flex gap-2 mt-4">
+            <Button variant="secondary" onClick={prevStep} disabled={processing}>
+              Back
+            </Button>
+            <Button onClick={handleSubmit} disabled={processing}>Finish</Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ProfileWizard;

--- a/resources/js/pages/ProfileWizard.tsx
+++ b/resources/js/pages/ProfileWizard.tsx
@@ -1,0 +1,11 @@
+import ProfileWizard from '@/components/ProfileWizard';
+import { Head } from '@inertiajs/react';
+
+export default function ProfileWizardPage() {
+  return (
+    <div className="min-h-screen flex items-center justify-center p-4 bg-background">
+      <Head title="Complete Profile" />
+      <ProfileWizard />
+    </div>
+  );
+}

--- a/resources/js/pages/Welcome2.tsx
+++ b/resources/js/pages/Welcome2.tsx
@@ -3,19 +3,15 @@ import { Head, useForm, Link } from '@inertiajs/react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Badge } from '@/components/ui/badge';
 import { Checkbox } from '@/components/ui/checkbox';
 import {
-    Target,
     UserPlus,
     User,
     Eye,
     EyeOff,
     Loader2,
     ArrowLeft,
-    CheckCircle,
-    AlertCircle,
     Globe,
     Sparkles
 } from 'lucide-react';
@@ -115,29 +111,17 @@ const translations = {
 export default function Welcome2({ auth, locale = 'en' }: Welcome2Props) {
     const [currentView, setCurrentView] = useState<'home' | 'options' | 'register' | 'signin'>('home');
     const [showPassword, setShowPassword] = useState(false);
-    const [showConfirmPassword, setShowConfirmPassword] = useState(false);
     const [currentLang, setCurrentLang] = useState<'en' | 'ar'>(locale as 'en' | 'ar');
 
     const t = translations[currentLang];
     const isRTL = currentLang === 'ar';
 
-    // Registration form - FIXED: Added all fields backend expects
     const { data: newUserData, setData: setNewUserData, post: postNewUser, processing: processingNewUser, errors: newUserErrors } = useForm({
         name: '',
         email: '',
         password: '',
         password_confirmation: '',
         company_name: '',
-        position: '',
-        phone: '',
-        city: '',
-        industry: '',
-        company_size: '',
-        website: '', // Added missing field
-        how_did_you_hear: '', // Added missing field
-        marketing_emails: true, // Added missing field
-        newsletter_subscription: false, // Added missing field
-        agree_terms: false,
     });
 
     // Login form
@@ -155,7 +139,8 @@ export default function Welcome2({ auth, locale = 'en' }: Welcome2Props) {
         console.log('Form data:', newUserData);
         console.log('Available routes:', window.route);
 
-        // Enhanced client-side validation
+        setNewUserData('password_confirmation', newUserData.password);
+
         if (!newUserData.name.trim()) {
             alert('Please enter your full name');
             return;
@@ -176,13 +161,8 @@ export default function Welcome2({ auth, locale = 'en' }: Welcome2Props) {
             return;
         }
 
-        if (newUserData.password !== newUserData.password_confirmation) {
-            alert('Passwords do not match');
-            return;
-        }
-
-        if (!newUserData.agree_terms) {
-            alert('Please agree to terms and conditions');
+        if (!newUserData.company_name.trim()) {
+            alert('Please enter your company name');
             return;
         }
 
@@ -197,7 +177,7 @@ export default function Welcome2({ auth, locale = 'en' }: Welcome2Props) {
             try {
                 routeUrl = route(routeName);
                 console.log('Using route:', routeName, 'URL:', routeUrl);
-            } catch (e) {
+            } catch {
                 console.log('Route user.register-free not found, trying alternatives...');
 
                 // Try alternative routes
@@ -209,7 +189,7 @@ export default function Welcome2({ auth, locale = 'en' }: Welcome2Props) {
                         routeName = altRoute;
                         console.log('Using alternative route:', routeName, 'URL:', routeUrl);
                         break;
-                    } catch (e2) {
+                    } catch {
                         console.log('Route', altRoute, 'not found');
                     }
                 }
@@ -224,6 +204,7 @@ export default function Welcome2({ auth, locale = 'en' }: Welcome2Props) {
             postNewUser(routeUrl, {
                 onSuccess: (response) => {
                     console.log('Registration successful:', response);
+                    setCurrentView('options');
                 },
                 onError: (errors) => {
                     console.error('Registration errors:', errors);
@@ -286,7 +267,7 @@ export default function Welcome2({ auth, locale = 'en' }: Welcome2Props) {
             try {
                 routeUrl = route(routeName);
                 console.log('Using login route:', routeName, 'URL:', routeUrl);
-            } catch (e) {
+            } catch {
                 console.log('Route login not found, trying alternatives...');
 
                 // Try alternative routes
@@ -298,7 +279,7 @@ export default function Welcome2({ auth, locale = 'en' }: Welcome2Props) {
                         routeName = altRoute;
                         console.log('Using alternative login route:', routeName, 'URL:', routeUrl);
                         break;
-                    } catch (e2) {
+                    } catch {
                         console.log('Login route', altRoute, 'not found');
                     }
                 }
@@ -595,35 +576,6 @@ export default function Welcome2({ auth, locale = 'en' }: Welcome2Props) {
                                             )}
                                         </div>
 
-                                        {/* Confirm Password */}
-                                        <div>
-                                            <Label htmlFor="password_confirmation" className="text-blue-900 text-sm font-semibold mb-2 block">
-                                                {t.confirmPassword} <span className="text-red-500">*</span>
-                                            </Label>
-                                            <div className="relative">
-                                                <Input
-                                                    id="password_confirmation"
-                                                    type={showConfirmPassword ? "text" : "password"}
-                                                    value={newUserData.password_confirmation}
-                                                    onChange={(e) => setNewUserData('password_confirmation', e.target.value)}
-                                                    className="border-blue-200 focus:border-blue-500 focus:ring-blue-500 h-12 rounded-xl pr-12"
-                                                    placeholder={t.confirmPassword}
-                                                    required
-                                                    minLength={8}
-                                                />
-                                                <button
-                                                    type="button"
-                                                    onClick={() => setShowConfirmPassword(!showConfirmPassword)}
-                                                    className="absolute right-3 top-1/2 transform -translate-y-1/2 text-blue-500"
-                                                >
-                                                    {showConfirmPassword ? <EyeOff className="w-5 h-5" /> : <Eye className="w-5 h-5" />}
-                                                </button>
-                                            </div>
-                                            {newUserErrors.password_confirmation && (
-                                                <p className="text-red-500 text-xs mt-1">{newUserErrors.password_confirmation}</p>
-                                            )}
-                                        </div>
-
                                         {/* Company Name */}
                                         <div>
                                             <Label htmlFor="company_name" className="text-blue-900 text-sm font-semibold mb-2 block">
@@ -638,109 +590,14 @@ export default function Welcome2({ auth, locale = 'en' }: Welcome2Props) {
                                                 placeholder={t.companyName}
                                             />
                                         </div>
-
-                                        {/* Position */}
-                                        <div>
-                                            <Label htmlFor="position" className="text-blue-900 text-sm font-semibold mb-2 block">
-                                                {t.position}
-                                            </Label>
-                                            <Input
-                                                id="position"
-                                                type="text"
-                                                value={newUserData.position}
-                                                onChange={(e) => setNewUserData('position', e.target.value)}
-                                                className="border-blue-200 focus:border-blue-500 focus:ring-blue-500 h-12 rounded-xl"
-                                                placeholder={t.position}
-                                            />
-                                        </div>
-
-                                        {/* Phone */}
-                                        <div>
-                                            <Label htmlFor="phone" className="text-blue-900 text-sm font-semibold mb-2 block">
-                                                {t.phone}
-                                            </Label>
-                                            <Input
-                                                id="phone"
-                                                type="tel"
-                                                value={newUserData.phone}
-                                                onChange={(e) => setNewUserData('phone', e.target.value)}
-                                                className="border-blue-200 focus:border-blue-500 focus:ring-blue-500 h-12 rounded-xl"
-                                                placeholder="+96600000000"
-                                            />
-                                        </div>
-
-                                        {/* City */}
-                                        <div>
-                                            <Label htmlFor="city" className="text-blue-900 text-sm font-semibold mb-2 block">
-                                                {t.city}
-                                            </Label>
-                                            <Input
-                                                id="city"
-                                                type="text"
-                                                value={newUserData.city}
-                                                onChange={(e) => setNewUserData('city', e.target.value)}
-                                                className="border-blue-200 focus:border-blue-500 focus:ring-blue-500 h-12 rounded-xl"
-                                                placeholder={t.city}
-                                            />
-                                        </div>
-
-                                        {/* Industry */}
-                                        <div>
-                                            <Label htmlFor="industry" className="text-blue-900 text-sm font-semibold mb-2 block">
-                                                {t.industry}
-                                            </Label>
-                                            <Select onValueChange={(value) => setNewUserData('industry', value)}>
-                                                <SelectTrigger className="border-blue-200 focus:border-blue-500 focus:ring-blue-500 h-12 rounded-xl">
-                                                    <SelectValue placeholder={t.industry} />
-                                                </SelectTrigger>
-                                                <SelectContent>
-                                                    <SelectItem value="service">{t.service}</SelectItem>
-                                                    <SelectItem value="manufacturing">{t.manufacturing}</SelectItem>
-                                                    <SelectItem value="commercial">{t.commercial}</SelectItem>
-                                                </SelectContent>
-                                            </Select>
-                                        </div>
-
-                                        {/* Company Size */}
-                                        <div>
-                                            <Label htmlFor="company_size" className="text-blue-900 text-sm font-semibold mb-2 block">
-                                                {t.companySize}
-                                            </Label>
-                                            <Select onValueChange={(value) => setNewUserData('company_size', value)}>
-                                                <SelectTrigger className="border-blue-200 focus:border-blue-500 focus:ring-blue-500 h-12 rounded-xl">
-                                                    <SelectValue placeholder={t.companySize} />
-                                                </SelectTrigger>
-                                                <SelectContent>
-                                                    <SelectItem value="1-10">1-10 {t.employees}</SelectItem>
-                                                    <SelectItem value="11-50">11-50 {t.employees}</SelectItem>
-                                                    <SelectItem value="51-200">51-200 {t.employees}</SelectItem>
-                                                    <SelectItem value="201-500">201-500 {t.employees}</SelectItem>
-                                                    <SelectItem value="501-1000">501-1000 {t.employees}</SelectItem>
-                                                    <SelectItem value="1000+">1000+ {t.employees}</SelectItem>
-                                                </SelectContent>
-                                            </Select>
-                                        </div>
-                                    </div>
-
-                                    {/* Terms Agreement */}
-                                    <div className="mt-6 flex items-center space-x-3">
-                                        <Checkbox
-                                            id="agree_terms"
-                                            checked={newUserData.agree_terms}
-                                            onCheckedChange={(checked) => setNewUserData('agree_terms', !!checked)}
-                                            className="border-blue-300 data-[state=checked]:bg-blue-600"
-                                        />
-                                        <label htmlFor="agree_terms" className="text-blue-900 text-sm cursor-pointer">
-                                            {t.agreeTerms}
-                                        </label>
                                     </div>
 
                                     {/* Submit Button */}
                                     <div className="mt-6 text-center">
                                         <Button
                                             type="submit"
-                                            disabled={processingNewUser || !newUserData.agree_terms}
-                                            className="bg-gradient-to-r from-blue-600 to-blue-800 hover:from-blue-700 hover:to-blue-900 text-white px-12 py-3 rounded-xl font-semibold"
+                                            disabled={processingNewUser}
+                        className="bg-gradient-to-r from-blue-600 to-blue-800 hover:from-blue-700 hover:to-blue-900 text-white px-12 py-3 rounded-xl font-semibold"
                                         >
                                             {processingNewUser ? (
                                                 <>

--- a/routes/web.php
+++ b/routes/web.php
@@ -194,10 +194,21 @@ Route::middleware(['auth', 'verified'])->group(function () {
 
     Route::middleware(['checkAccess:premium'])->group(function () {
 
+        Route::get('/profile/setup', function () {
+            return Inertia::render('ProfileWizard');
+        })->name('profile.setup');
+
+        Route::post('/profile/setup', [UserRegistrationController::class, 'completeProfile'])
+            ->name('profile.complete');
+
         // Dashboard access
-                 Route::get('dashboard', function () {
-                return Inertia::render('dashboard');
-            })->name('dashboard');
+        Route::get('dashboard', function () {
+            $user = auth()->user();
+            if (!$user->hasCompletedProfile()) {
+                return redirect()->route('profile.setup');
+            }
+            return Inertia::render('dashboard');
+        })->name('dashboard');
 
         // Assessment tools access
         Route::get('/assessment-tools', [AssessmentToolsController::class, 'index'])


### PR DESCRIPTION
## Summary
- streamline registration form to only capture name, email, password, and company
- introduce a two-step profile setup wizard
- display profile wizard after successful registration
- validate minimal fields server-side and create basic user details
- redirect first-time dashboard users to full-page profile wizard and persist phone/address details

## Testing
- `npm run lint` *(fails: Tag is defined but never used)*
- `npx eslint resources/js/pages/Welcome2.tsx resources/js/components/ProfileWizard.tsx resources/js/pages/ProfileWizard.tsx && echo 'eslint success'`
- `npm run types` *(fails: File name differs only in casing)*
- `php artisan test` *(fails: No application encryption key has been specified)*

------
https://chatgpt.com/codex/tasks/task_e_688f18f300f48331b0b574c273f6e663